### PR TITLE
Conveyor version 0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 #Conveyor Changelog
 
+## Version 0.3.0
+
+Unreleased
+
+
+## Version 0.2.0
+
+Released 3-4-20
+
+Extracted helper functions into conveyor-schema library (not backwards compatible change)
+
+
 ## Version 0.1.0
 
 Released 2-25-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autoinvent/conveyor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autoinvent/conveyor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A frontend dashboard generator for inventory data.",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
publish conveyor version 0.2.0

compatible with conveyor-schema 0.1.0

changes: extracted helper functions into conveyor-schema library

changes not backwards compatible