### PR TITLE
Removed href=# (anchor to top of page) from PaginationLink

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -171,3 +171,7 @@ body {
   color: #5f5f5f;
   margin-bottom: 2px;
 }
+
+.page-link {
+  cursor: pointer;
+}

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -59,7 +59,6 @@ const PaginationLink = ({
 }) => {
   const link = <a
     className='page-link'
-    href='#'
     onClick={() => onChangePage({
       modelName, fieldName, updatedPageIndex
     })}


### PR DESCRIPTION
The pagination link components previously had a `href="#"` prop which scrolled the user to the top of the page. This causes issues when the user clicks on the pagination number to input the page they want to go to--it will scroll them to the top of the page, and then they will have to scroll down to input the number. This change makes it so the user will stay on the bottom of the page when they paginate and will have to scroll to the top of the page themselves. 

If this behavior is not wanted, we will have to programmatically scroll the user to the top of the page (not using '#' anchor tag) only when they click on the arrows and not on the pagination number (to input the page they want to go to). It will then also have to trigger when they submit the page they want to go to.