### PR TITLE
add spellchecking to string / textarea input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 Unreleased
 
+Added spellCheck to input types: String, TextArea
 Fixed CollapseTableIcon being set to FaAngleDown instead of FaAngleRight when collapsed
 Removed href=# (anchor to top of page) from PaginationLink
 

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -100,6 +100,7 @@ const FlexibleInput = props => {
    *      not available for 'Checkbox' type
    * @param { boolean } [autoFocus] refers to specific fields (see isAutoFocusInput()) that have
    *      autofocus input feature
+   * @param { boolean } [spellCheck] - adds spell checking to the input box. Available for "String" and "TextArea" types.
    *
    * @returns { object } - Single input component
    */
@@ -108,10 +109,16 @@ const FlexibleInput = props => {
 
   switch (params.type) {
     case inputTypes.STRING_TYPE:
+      params['spellCheck'] = R.defaultTo(true, params['spellCheck'])
+      break
+
     case inputTypes.EMAIL_TYPE:
     case inputTypes.PHONE_TYPE:
     case inputTypes.URL_TYPE:
     case inputTypes.TEXTAREA_TYPE:
+      params['spellCheck'] = R.defaultTo(true, params['spellCheck'])
+      break
+
     case inputTypes.INT_TYPE:
     case inputTypes.PASSWORD_TYPE:
     case inputTypes.CURRENCY_TYPE:

--- a/src/input/inputComponent.js
+++ b/src/input/inputComponent.js
@@ -128,9 +128,10 @@ const inputStringTypeMap = {
  * @property { function } customError
  * @property { function } customLabel
  * @property { boolean } autoFocus; update isAutoFocusInput() when changing
+ * @property { boolean } spellCheck
  */
 
-export const InputString = ({ type, onChange, id, labelStr, error, value, className, required, customInput, customError, customLabel, autoFocus, onKeyDown }) => (
+export const InputString = ({ type, onChange, id, labelStr, error, value, className, required, customInput, customError, customLabel, autoFocus, onKeyDown, spellCheck }) => (
   <FormGroup labelStr={labelStr} htmlFor={id} error={error} required={required}
     customError={R.defaultTo(null, customError)}
     customLabel={customLabel}>
@@ -142,6 +143,7 @@ export const InputString = ({ type, onChange, id, labelStr, error, value, classN
       id={id}
       value={value}
       onKeyDown={onKeyDown}
+      spellCheck={spellCheck}
       {...customInput}
     />
   </FormGroup>
@@ -276,9 +278,10 @@ export const InputCurrency = ({ onChange, id, labelStr, error, value, className,
  * @property { function } customError
  * @property { function } customLabel
  * @property { boolean } autoFocus; update isAutoFocusInput() when changing
+ * @property { boolean } spellCheck
  */
 
-export const InputTextArea = ({ onChange, id, labelStr, error, value, className, required, customInput, customError, customLabel, autoFocus }) => (
+export const InputTextArea = ({ onChange, id, labelStr, error, value, className, required, customInput, customError, customLabel, autoFocus, spellCheck }) => (
   <FormGroup labelStr={labelStr} htmlFor={id} error={error} required={required}
     customError={R.defaultTo(null, customError)}
     customLabel={customLabel}>
@@ -288,6 +291,7 @@ export const InputTextArea = ({ onChange, id, labelStr, error, value, className,
       value={value}
       onChange={evt => onChange(evt.target.value)}
       id={id}
+      spellCheck={spellCheck}
       {...customInput}
     />
   </FormGroup>


### PR DESCRIPTION
Adds a spellcheck boolean to `input` that enables spellchecking on `String` and `TextArea` types.  Default value is `true`