### PR TITLE
removed useContent prop from react-tippy Tooltip component

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -37,7 +37,6 @@ const RelTooltip = ({ schema, modelName, id, data, children }) => {
   const actions = schema.getActions(modelName)
   const tooltipOpened = R.path(['tooltip', 'onTooltipOpen'], actions)
   return <Tooltip
-    useContext
     interactive
     html={<RelTooltipContent data={data} />}
     delay={0}


### PR DESCRIPTION
React Tippy's Tooltip compenent would cause inline links in a single cell to jump onto a new line, giving the appearance of re-ordering them on mouse-over.
I removed the useContext prop from the Tooltip component to correct that behavior. There doesn't seem to be any loss of functionality in doing so.
Here is the description of that prop's functionality from the docs:
_Define that you're using context in your tooltip content (or html props). It's useful when you want your tooltip content can connect to redux store_
https://github.com/tvkhoa/react-tippy
We are passing values from Redux into the Tooltip as props, but I don't believe they need to be connected to the store themselves, as the data is static. (At this point)
