### PR TITLE
prevent treetable toggle when clicking on cell item

### DIFF
--- a/src/TreeTable.js
+++ b/src/TreeTable.js
@@ -114,7 +114,9 @@ const renderRow = ({ tree, stateNode, toggleRow, iconPath, columnFields, renderF
         <div style={{ display: 'flex' }}>
           <Indentation {...{ depth: stateNode.depth }} />
           <Toggle {...{ stateNode, toggleRow, iconPath }} />
-          {fields[0]}
+          <div onClick={(e) => e.stopPropagation()}>
+            {fields[0]}
+          </div>
         </div>
       </td>
       {fields.slice(1).map((field, index) => (


### PR DESCRIPTION
BUG: clicking on a non-link item in TreeTable will always trigger the tree's toggle.  This can be unintended behavior if the user is, for example, clicking on a Select component to access a dropdown menu, or highlighting text to copy.

I added an `event.stopPropogation()` to fix this