### PR TITLE
fix TreeTable's first column cell items being too small

### DIFF
--- a/src/TreeTable.js
+++ b/src/TreeTable.js
@@ -114,7 +114,9 @@ const renderRow = ({ tree, stateNode, toggleRow, iconPath, columnFields, renderF
         <div style={{ display: 'flex' }}>
           <Indentation {...{ depth: stateNode.depth }} />
           <Toggle {...{ stateNode, toggleRow, iconPath }} />
-          {fields[0]}
+          <div style={{ flexGrow: 1 }}>
+            {fields[0]}
+          </div>
         </div>
       </td>
       {fields.slice(1).map((field, index) => (


### PR DESCRIPTION
Specifically the react-select component.  The fix adds `flexGrow: 1` to the main component in the cell to allow it to expand instead of being confined to the same width as the 'toggle' icon