### PR TITLE
Adding back use context

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.8.6",
     "react-icons": "^3.8.0",
     "react-select": "^3.0.4",
-    "react-tippy": "^1.2.3",
+    "react-tippy": "github:codebloodedchris/react-tippy",
     "react-window": "^1.8.5"
   },
   "peerDependencies": {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -37,6 +37,7 @@ const RelTooltip = ({ schema, modelName, id, data, children }) => {
   const actions = schema.getActions(modelName)
   const tooltipOpened = R.path(['tooltip', 'onTooltipOpen'], actions)
   return <Tooltip
+    useContext
     interactive
     html={<RelTooltipContent data={data} />}
     delay={0}


### PR DESCRIPTION
As it turns out, we need useContext prop for any links we want to place in the Tooltips.
So I've added it back in and found out that my inline styling bug was a bug in react-tippy itself.
I have an open issue with them here: https://github.com/tvkhoa/react-tippy/issues/147
In the meantime, I'm hosting a corrected version of react-tippy that I'm using for this project.