### PR TITLE
store File object directly

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autoinvent/conveyor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10585,9 +10585,8 @@
       }
     },
     "react-tippy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/react-tippy/-/react-tippy-1.2.3.tgz",
-      "integrity": "sha512-cEmhw29DbVP33n9ayo0nLzibuSz6o0A77cZtzno7zGsfOH8tUEGai/8a7TXRIKHPYDooW8iJkJBIPDnxmEu00g==",
+      "version": "github:codebloodedchris/react-tippy#d4244a50a85aff8911ddcc888820c450d990df4c",
+      "from": "github:codebloodedchris/react-tippy",
       "requires": {
         "popper.js": "^1.11.1"
       }

--- a/src/form/Input.js
+++ b/src/form/Input.js
@@ -134,29 +134,14 @@ export const getOnChange = ({ inputType, onChange, fieldName }) => {
     fieldName,
     value: val
   })
+
   if (inputType !== inputTypes.FILE_TYPE) {
     return defaultHandleOnChange
   }
 
   return (evt => {
-    const fileReader = new FileReader()
-
-    const onloadend = () => {
-      // handle result of read
-      if (!fileReader.error) {
-        const content = fileReader.result
-        // since cannot save ArrayBuffer to store, convert value
-        const converted = arrayBufferToStoreValue(content)
-        defaultHandleOnChange(converted)
-      } else {
-        // TODO handle error
-      }
-    }
-
     if (evt.target.files.length > 0) {
-      // initiate read
-      fileReader.onloadend = onloadend
-      fileReader.readAsArrayBuffer(evt.target.files[0])
+      defaultHandleOnChange(evt.target.files[0])
     }
   })
 }

--- a/src/input/inputComponent.js
+++ b/src/input/inputComponent.js
@@ -357,7 +357,6 @@ export const InputFile = ({ onChange, error, id, labelStr, className, required, 
       customLabel={customLabel}>
       <input
         type='file'
-        accept='image/*'
         onChange={onChange}
         className={`${className}${error ? ' is-invalid' : ''}`}
         id={id}


### PR DESCRIPTION
Supports the [multipart spec](https://github.com/jaydenseric/graphql-multipart-request-spec). graphql-request understands `File` objects now (autoinvent/magql-query#20), so they need to be stored directly rather than read into an array. Conveyor-redux passes them on without extra processing (autoinvent/conveyor-redux#30). The data will show up as an empty object in the Redux dev tools, but that's because it tries to convert it to a JSON object. The file is in fact present in the store.

I was only concerned with the form stack create submission for now, need to make sure this is cleaned up for other components too.