### PR TITLE
turn off pagination on model OR detail level

### DIFF
--- a/src/table/Table.js
+++ b/src/table/Table.js
@@ -414,6 +414,9 @@ export const Table = ({
   customProps,
   summary
 }) => {
+  const paginateIndex = R.propOr(true, 'paginate', schema.getModel(modelName))
+  const paginateDetail = R.pathOr(true, ['fields', parentFieldName, 'paginate'], schema.getModel(parentModelName))
+
   if (!fromIndex && collapse) {
     return null
   }
@@ -494,7 +497,7 @@ export const Table = ({
           }}
         />
       </table>
-      {fromIndex ? (
+      {paginateIndex && fromIndex ? (
         <IndexPagination
           {...{
             schema,
@@ -502,7 +505,7 @@ export const Table = ({
             tableView
           }}
         />
-      ) : (
+      ) : paginateDetail && (
         <DetailPagination
           {...{
             schema,


### PR DESCRIPTION
This adds the ability to use a  "paginate: false" attribute to the model level of the schema, effectively disabling pagination.
This PR disables the UI for the pagination, while this PR for conveyor-redux disables the page variable in the query:
https://github.com/autoinvent/conveyor-redux/pull/31

![image](https://user-images.githubusercontent.com/33336510/95375875-1b885180-0895-11eb-870e-c4b61ab13a02.png)
               Long list of Books
![image](https://user-images.githubusercontent.com/33336510/95375899-2511b980-0895-11eb-93df-e4eca0e72e90.png)
