### PR TITLE
refactorered exports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,97 +1,46 @@
-import Index from './Index'
-import Alerts from './Alerts'
-import Create from './form/Create'
-import CreateButton from './CreateButton'
-import { DefaultDetailTableTitleWrapper } from './Detail'
-import Detail from './Detail'
-import { DetailCreateButton } from './Detail'
-import DetailLink from './DetailLink'
-import { DisabledInput } from './form/Input'
-import { FieldToOne } from './table/Field'
-import FlexibleInput from './input/index'
-import Input from './form/Input'
-import { Modal } from './Modal'
-import RelTooltip from './Tooltip'
-import { storeValueToArrayBuffer } from './utils/fileConverters'
-import { TableButtonGroup } from './table/Table'
-import Tooltip from './Tooltip'
-import { TableRowWithEdit } from './table/Table'
-import { TableButtonCell } from './table/Table'
-import { toggleState } from './TreeTable'
-import { formatCSS } from './TreeTable'
-import { getRows } from './TreeTable'
-import { getOnChange } from './form/Input'
-import { isEditing } from './Edit'
-import { CollapseTableButton } from './Detail'
-import { DeleteDetail } from './delete/DeleteDetail'
-import { DeleteButton } from './table/Table'
-import { Search } from './Search'
+export { default as Index } from './Index'
+export { default as Alerts } from './Alerts'
+export { default as Create } from './form/Create'
+export { default as CreateButton } from './CreateButton'
+export { default as Detail, DefaultDetailTableTitleWrapper } from './Detail'
+export { DetailCreateButton } from './Detail'
+export { default as DetailLink } from './DetailLink'
+export { DisabledInput } from './form/Input'
+export { FieldToOne } from './table/Field'
+export { default as FlexibleInput } from './input/index'
+export { default as Input } from './form/Input'
+export { Modal } from './Modal'
+export { default as RelTooltip, Tooltip } from './Tooltip'
+export { storeValueToArrayBuffer } from './utils/fileConverters'
+export { TableButtonGroup } from './table/Table'
+export { TableRowWithEdit } from './table/Table'
+export { TableButtonCell } from './table/Table'
+export { toggleState } from './TreeTable'
+export { formatCSS } from './TreeTable'
+export { getRows } from './TreeTable'
+export { getOnChange } from './form/Input'
+export { isEditing } from './Edit'
+export { CollapseTableButton } from './Detail'
+export { DeleteDetail } from './delete/DeleteDetail'
+export { DeleteButton } from './table/Table'
+export { Search } from './Search'
 // model overrides
-import { DefaultDetail } from './Detail'
-import { RecursiveTab } from './Tabs'
-import { DetailFields } from './Detail'
-import { DefaultDetailPageTitle } from './Detail'
-import { DefaultIndex } from './Index'
-import { Table } from './table/Table'
-import { DefaultIndexTitle } from './Index'
-import { DefaultCreate } from './form/Create'
-import { DefaultCreatePage } from './form/Create'
-import { DefaultCreateTitle } from './form/Create'
+export { DefaultDetail } from './Detail'
+export { RecursiveTab } from './Tabs'
+export { DetailFields } from './Detail'
+export { DefaultDetailPageTitle } from './Detail'
+export { DefaultIndex } from './Index'
+export { Table } from './table/Table'
+export { DefaultIndexTitle } from './Index'
+export { DefaultCreate } from './form/Create'
+export { DefaultCreatePage } from './form/Create'
+export { DefaultCreateTitle } from './form/Create'
 // field overrides
-import { Field } from './table/Field'
-import { DefaultDetailAttribute } from './Detail'
-import { DefaultDetailTable } from './Detail'
-import { DefaultDetailLabel } from './Detail'
-import { DefaultDetailO2MTableTitle } from './Detail'
-import { DefaultDetailM2MFieldLabel } from './Detail'
-import { DefaultDetailM2MTableTitle } from './Detail'
-import { InputCore } from './form/Input'
-
-export { Index }
-export { Alerts }
-export { Create }
-export { CreateButton }
-export { DefaultDetailTableTitleWrapper }
-export { Detail }
-export { DetailCreateButton }
-export { DetailLink }
-export { DisabledInput }
-export { FieldToOne }
-export { FlexibleInput }
-export { Input }
-export { Modal }
-export { RelTooltip }
-export { storeValueToArrayBuffer }
-export { TableButtonGroup }
-export { Tooltip }
-export { TableRowWithEdit }
-export { TableButtonCell }
-export { toggleState }
-export { formatCSS }
-export { getRows }
-export { getOnChange }
-export { isEditing }
-export { CollapseTableButton }
-export { DeleteDetail }
-export { DeleteButton }
-export { Search }
-// model overrides
-export { DefaultDetail }
-export { RecursiveTab }
-export { DetailFields }
-export { DefaultDetailPageTitle }
-export { DefaultIndex }
-export { Table }
-export { DefaultIndexTitle }
-export { DefaultCreate }
-export { DefaultCreatePage }
-export { DefaultCreateTitle }
-// field overrides
-export { Field }
-export { DefaultDetailAttribute }
-export { DefaultDetailTable }
-export { DefaultDetailLabel }
-export { DefaultDetailO2MTableTitle }
-export { DefaultDetailM2MFieldLabel }
-export { DefaultDetailM2MTableTitle }
-export { InputCore }
+export { Field } from './table/Field'
+export { DefaultDetailAttribute } from './Detail'
+export { DefaultDetailTable } from './Detail'
+export { DefaultDetailLabel } from './Detail'
+export { DefaultDetailO2MTableTitle } from './Detail'
+export { DefaultDetailM2MFieldLabel } from './Detail'
+export { DefaultDetailM2MTableTitle } from './Detail'
+export { InputCore } from './form/Input'


### PR DESCRIPTION
Alerts was not exporting correctly. While having a named and default export is valid ES6 syntax, it was causing an issue with the method being used to export the required methods.
I refactored all the exports into a less verbose, clearer to read syntax is that is now working for the Alerts component.

fixes #61 