### PR TITLE
Fix disappearing select options, broken initialOffset

### DIFF
--- a/src/utils/optimizeSelect.js
+++ b/src/utils/optimizeSelect.js
@@ -1,5 +1,6 @@
 import { components } from 'react-select'
 import React from 'react'
+import _ from 'lodash'
 import { FixedSizeList as List } from 'react-window'
 
 const OptimizedMenuList = props => {
@@ -7,15 +8,16 @@ const OptimizedMenuList = props => {
   if (!children || !Array.isArray(children)) return children
 
   const height = 38
+  const listHeight = height * children.length
   const [value] = getValue()
   const initialOffset = value
-    ? options.indexOf(value) * height
+    ? options.findIndex(obj => _.isEqual(obj, value)) * height
     : 0
 
   return (
     <List
       width="100%"
-      height={Math.min(maxHeight, height * children.length)}
+      height={Math.min(maxHeight, listHeight)}
       itemCount={children.length}
       itemSize={height}
       initialScrollOffset={initialOffset}

--- a/src/utils/optimizeSelect.js
+++ b/src/utils/optimizeSelect.js
@@ -1,6 +1,6 @@
 import { components } from 'react-select'
 import React from 'react'
-import _ from 'lodash'
+import * as R from 'ramda'
 import { FixedSizeList as List } from 'react-window'
 
 const OptimizedMenuList = props => {
@@ -11,7 +11,7 @@ const OptimizedMenuList = props => {
   const listHeight = height * children.length
   const [value] = getValue()
   const initialOffset = value && maxHeight < listHeight
-    ? options.findIndex(obj => _.isEqual(obj, value)) * height
+    ? options.findIndex(obj => R.equals(obj, value)) * height
     : 0
 
   return (

--- a/src/utils/optimizeSelect.js
+++ b/src/utils/optimizeSelect.js
@@ -10,7 +10,7 @@ const OptimizedMenuList = props => {
   const height = 38
   const listHeight = height * children.length
   const [value] = getValue()
-  const initialOffset = value
+  const initialOffset = value && maxHeight < listHeight
     ? options.findIndex(obj => _.isEqual(obj, value)) * height
     : 0
 


### PR DESCRIPTION
We are using `array.indexOf` to calculate initialOffset value, which doesn't work on objects with identical values but different references.  I switched it to ramda's `R.equals`, but am also using `findIndex` which isn't supported on IE.

Items were also disappearing on `OptimizedMenuList` (seems like it's only when there is no scrollbar).  I fixed this by setting `initialOffset` to 0 when the height of the list is less than the `maxHeight`