### PR TITLE
on fields, enable custom no-data string with default 'N/A'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+Added noDataDisplayValue to fields, which displays custom values when there is no data
 Added Alerts component
 
 

--- a/quick_docs/schema.rst
+++ b/quick_docs/schema.rst
@@ -40,6 +40,7 @@ The schema utilized by the framework will be different than the existing schema 
           fieldName: "" #Name of the field, used as the key in fields dictionary
           fieldHelp: "" #Text to display under the field when it is being edited
           displayName: "" or function #Provides how the field should be displayed or function that calculates displayName
+          noDataDisplayString: "" #Text to display when a field has no data
           detailAttribute: boolean #Determines whether or not a field should display in the attribute or table section of a detail page
           type:  "" #When type is a string it provides the type of a simple type such as string, int, or date
           OR

--- a/quick_docs/schema.rst
+++ b/quick_docs/schema.rst
@@ -40,7 +40,7 @@ The schema utilized by the framework will be different than the existing schema 
           fieldName: "" #Name of the field, used as the key in fields dictionary
           fieldHelp: "" #Text to display under the field when it is being edited
           displayName: "" or function #Provides how the field should be displayed or function that calculates displayName
-          noDataDisplayString: "" #Text to display when a field has no data
+          noDataDisplayValue: "" or function #Value to display when a field has no data
           detailAttribute: boolean #Determines whether or not a field should display in the attribute or table section of a detail page
           type:  "" #When type is a string it provides the type of a simple type such as string, int, or date
           OR

--- a/src/table/Field.js
+++ b/src/table/Field.js
@@ -13,9 +13,9 @@ export const getRelSchemaEntry = ({ schema, modelName, fieldName }) => {
   return schema.getModel(fieldTargetModel)
 }
 
-const FieldString = ({ schema, modelName, fieldName, node, noDataDisplayString }) => {
+const FieldString = ({ schema, modelName, fieldName, node, noDataDisplayValue }) => {
   const value = R.prop(fieldName, node)
-  const displayString = (R.isNil(value) || value === '') ? noDataDisplayString : value
+  const displayString = (R.isNil(value) || value === '') ? noDataDisplayValue : value
 
   return (
     <span className='text-area-display'>{displayString}</span>
@@ -31,11 +31,11 @@ const FieldBoolean = ({ schema, modelName, fieldName, node }) => {
 
 // Render a link to the value. If the value does not start with any of the prefixes,
 // append the first prefix. Produces HTTPS URLs by default.
-const FieldLink = ({ schema, modelName, fieldName, node, prefix = ['https://', 'http://'], noDataDisplayString }) => {
+const FieldLink = ({ schema, modelName, fieldName, node, prefix = ['https://', 'http://'], noDataDisplayValue }) => {
   // Ensure prefix is a list, allowing a single string instead of a list.
   prefix = R.pipe(R.prepend(prefix), R.flatten)([])
   let href = R.prop(fieldName, node)
-  if (!href) { return <span>{noDataDisplayString}</span> }
+  if (!href) { return <span>{noDataDisplayValue}</span> }
 
   const displayString = href
 
@@ -55,14 +55,14 @@ const FieldCurrency = ({ schema, modelName, fieldName, node }) => {
   )
 }
 
-const FieldEnum = ({ schema, modelName, fieldName, node, noDataDisplayString }) => {
+const FieldEnum = ({ schema, modelName, fieldName, node, noDataDisplayValue }) => {
   const value = R.prop(fieldName, node)
   if (value) {
     return (
       <span>{ schema.getEnumLabel(modelName, fieldName, value) }</span>
     )
   }
-  return <span>{noDataDisplayString}</span>
+  return <span>{noDataDisplayValue}</span>
 }
 
 const FieldImageModal = ({ schema, modelName, fieldName, id, node, customProps }) => {
@@ -73,7 +73,7 @@ const FieldImageModal = ({ schema, modelName, fieldName, id, node, customProps }
   return <ImageLinkModal {...{ id: modalId, title: label, url }} />
 }
 
-export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, noDataDisplayString, customProps }) => {
+export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, noDataDisplayValue, customProps }) => {
   const relSchemaEntry = getRelSchemaEntry({ schema, modelName, fieldName })
 
   const relModelName = R.prop('modelName', relSchemaEntry)
@@ -81,7 +81,7 @@ export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, no
   const displayString = schema.getDisplayValue({ modelName: relModelName, node, customProps })
   const relId = R.prop('id', node)
 
-  if (!displayString) { return <span>{noDataDisplayString}</span> }
+  if (!displayString) { return <span>{noDataDisplayValue}</span> }
 
   const displayTooltip = (schema.getTooltipFields({ modelName: relModelName, customProps }).length !== 0)
   if (displayTooltip) {
@@ -112,7 +112,7 @@ export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, no
   }
 }
 
-export const FieldToMany = ({ schema, modelName, fieldName, tooltipData, node, noDataDisplayString }) => {
+export const FieldToMany = ({ schema, modelName, fieldName, tooltipData, node, noDataDisplayValue }) => {
   const multiRelField = R.prop(fieldName, node)
 
   const relListWithLink = (field, idx, obj) => (
@@ -127,7 +127,7 @@ export const FieldToMany = ({ schema, modelName, fieldName, tooltipData, node, n
 
   return (
     <span>{ (multiRelField && multiRelField.length > 0)
-      ? multiRelField.map(relListWithLink) : noDataDisplayString}
+      ? multiRelField.map(relListWithLink) : noDataDisplayValue}
     </span>
   )
 }
@@ -144,7 +144,7 @@ export const Field = ({ schema, modelName, fieldName, tooltipData, node, id, cus
   }
 
   const type = schema.getType(modelName, fieldName)
-  const noDataDisplayString = R.pathOr('N/A', ['fields', fieldName, 'noDataDisplayString'], schema.getModel(modelName))
+  const noDataDisplayValue = schema.getNoDataDisplayValue({ modelName, fieldName, node, customProps })
 
   switch (type) {
     case consts.inputTypes.STRING_TYPE:
@@ -153,17 +153,17 @@ export const Field = ({ schema, modelName, fieldName, tooltipData, node, id, cus
     case consts.inputTypes.DATE_TYPE:
     case consts.inputTypes.TEXTAREA_TYPE:
     case consts.inputTypes.CREATABLE_STRING_SELECT_TYPE:
-      return <FieldString {...{ noDataDisplayString, ...props }} />
+      return <FieldString {...{ noDataDisplayValue, ...props }} />
     case consts.inputTypes.ENUM_TYPE:
-      return <FieldEnum {...{ noDataDisplayString, ...props }} />
+      return <FieldEnum {...{ noDataDisplayValue, ...props }} />
     case consts.inputTypes.URL_TYPE:
-      return <FieldLink {...{ noDataDisplayString, ...props }} />
+      return <FieldLink {...{ noDataDisplayValue, ...props }} />
     case consts.inputTypes.FILE_TYPE:
       return <FieldImageModal {...props} />
     case consts.inputTypes.PHONE_TYPE:
-      return <FieldLink {...{ prefix: 'tel:', noDataDisplayString, ...props }} />
+      return <FieldLink {...{ prefix: 'tel:', noDataDisplayValue, ...props }} />
     case consts.inputTypes.EMAIL_TYPE:
-      return <FieldLink {...{ prefix: 'mailto:', noDataDisplayString, ...props }} />
+      return <FieldLink {...{ prefix: 'mailto:', noDataDisplayValue, ...props }} />
     case consts.inputTypes.BOOLEAN_TYPE:
       return <FieldBoolean {...props} />
     case consts.inputTypes.CURRENCY_TYPE:
@@ -176,11 +176,11 @@ export const Field = ({ schema, modelName, fieldName, tooltipData, node, id, cus
         modelName,
         fieldName,
         tooltipData,
-        noDataDisplayString
+        noDataDisplayValue
       }} />
     case consts.inputTypes.MANY_TO_MANY_TYPE:
     case consts.inputTypes.ONE_TO_MANY_TYPE:
-      return <FieldToMany {...{ noDataDisplayString, ...props }} />
+      return <FieldToMany {...{ noDataDisplayValue, ...props }} />
     case consts.inputTypes.ONE_TO_ONE_TYPE:
       return <span>OneToOne</span>
     default:

--- a/src/table/Field.js
+++ b/src/table/Field.js
@@ -13,9 +13,9 @@ export const getRelSchemaEntry = ({ schema, modelName, fieldName }) => {
   return schema.getModel(fieldTargetModel)
 }
 
-const FieldString = ({ schema, modelName, fieldName, node }) => {
+const FieldString = ({ schema, modelName, fieldName, node, noDataDisplayString }) => {
   const value = R.prop(fieldName, node)
-  const displayString = (R.isNil(value) || value === '') ? 'N/A' : value
+  const displayString = (R.isNil(value) || value === '') ? noDataDisplayString : value
 
   return (
     <span className='text-area-display'>{displayString}</span>
@@ -31,11 +31,11 @@ const FieldBoolean = ({ schema, modelName, fieldName, node }) => {
 
 // Render a link to the value. If the value does not start with any of the prefixes,
 // append the first prefix. Produces HTTPS URLs by default.
-const FieldLink = ({ schema, modelName, fieldName, node, prefix = ['https://', 'http://']}) => {
+const FieldLink = ({ schema, modelName, fieldName, node, prefix = ['https://', 'http://'], noDataDisplayString }) => {
   // Ensure prefix is a list, allowing a single string instead of a list.
   prefix = R.pipe(R.prepend(prefix), R.flatten)([])
   let href = R.prop(fieldName, node)
-  if (!href) { return <span>N/A</span> }
+  if (!href) { return <span>{noDataDisplayString}</span> }
 
   const displayString = href
 
@@ -55,14 +55,14 @@ const FieldCurrency = ({ schema, modelName, fieldName, node }) => {
   )
 }
 
-const FieldEnum = ({ schema, modelName, fieldName, node }) => {
+const FieldEnum = ({ schema, modelName, fieldName, node, noDataDisplayString }) => {
   const value = R.prop(fieldName, node)
   if (value) {
     return (
       <span>{ schema.getEnumLabel(modelName, fieldName, value) }</span>
     )
   }
-  return <span>{ 'N/A' }</span>
+  return <span>{noDataDisplayString}</span>
 }
 
 const FieldImageModal = ({ schema, modelName, fieldName, id, node, customProps }) => {
@@ -73,7 +73,7 @@ const FieldImageModal = ({ schema, modelName, fieldName, id, node, customProps }
   return <ImageLinkModal {...{ id: modalId, title: label, url }} />
 }
 
-export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, customProps }) => {
+export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, noDataDisplayString, customProps }) => {
   const relSchemaEntry = getRelSchemaEntry({ schema, modelName, fieldName })
 
   const relModelName = R.prop('modelName', relSchemaEntry)
@@ -81,7 +81,7 @@ export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, cu
   const displayString = schema.getDisplayValue({ modelName: relModelName, node, customProps })
   const relId = R.prop('id', node)
 
-  if (!displayString) { return <span>N/A</span> }
+  if (!displayString) { return <span>{noDataDisplayString}</span> }
 
   const displayTooltip = (schema.getTooltipFields({ modelName: relModelName, customProps }).length !== 0)
   if (displayTooltip) {
@@ -112,7 +112,7 @@ export const FieldToOne = ({ schema, modelName, fieldName, node, tooltipData, cu
   }
 }
 
-export const FieldToMany = ({ schema, modelName, fieldName, tooltipData, node }) => {
+export const FieldToMany = ({ schema, modelName, fieldName, tooltipData, node, noDataDisplayString }) => {
   const multiRelField = R.prop(fieldName, node)
 
   const relListWithLink = (field, idx, obj) => (
@@ -127,7 +127,7 @@ export const FieldToMany = ({ schema, modelName, fieldName, tooltipData, node })
 
   return (
     <span>{ (multiRelField && multiRelField.length > 0)
-      ? multiRelField.map(relListWithLink) : 'N/A'}
+      ? multiRelField.map(relListWithLink) : noDataDisplayString}
     </span>
   )
 }
@@ -144,6 +144,7 @@ export const Field = ({ schema, modelName, fieldName, tooltipData, node, id, cus
   }
 
   const type = schema.getType(modelName, fieldName)
+  const noDataDisplayString = R.pathOr('N/A', ['fields', fieldName, 'noDataDisplayString'], schema.getModel(modelName))
 
   switch (type) {
     case consts.inputTypes.STRING_TYPE:
@@ -152,17 +153,17 @@ export const Field = ({ schema, modelName, fieldName, tooltipData, node, id, cus
     case consts.inputTypes.DATE_TYPE:
     case consts.inputTypes.TEXTAREA_TYPE:
     case consts.inputTypes.CREATABLE_STRING_SELECT_TYPE:
-      return <FieldString {...props} />
+      return <FieldString {...{ noDataDisplayString, ...props }} />
     case consts.inputTypes.ENUM_TYPE:
-      return <FieldEnum {...props} />
+      return <FieldEnum {...{ noDataDisplayString, ...props }} />
     case consts.inputTypes.URL_TYPE:
-      return <FieldLink {...props} />
+      return <FieldLink {...{ noDataDisplayString, ...props }} />
     case consts.inputTypes.FILE_TYPE:
       return <FieldImageModal {...props} />
     case consts.inputTypes.PHONE_TYPE:
-      return <FieldLink {...{ prefix: 'tel:', ...props }} />
+      return <FieldLink {...{ prefix: 'tel:', noDataDisplayString, ...props }} />
     case consts.inputTypes.EMAIL_TYPE:
-      return <FieldLink {...{ prefix: 'mailto:', ...props }} />
+      return <FieldLink {...{ prefix: 'mailto:', noDataDisplayString, ...props }} />
     case consts.inputTypes.BOOLEAN_TYPE:
       return <FieldBoolean {...props} />
     case consts.inputTypes.CURRENCY_TYPE:
@@ -174,11 +175,12 @@ export const Field = ({ schema, modelName, fieldName, tooltipData, node, id, cus
         schema,
         modelName,
         fieldName,
-        tooltipData
+        tooltipData,
+        noDataDisplayString
       }} />
     case consts.inputTypes.MANY_TO_MANY_TYPE:
     case consts.inputTypes.ONE_TO_MANY_TYPE:
-      return <FieldToMany {...props} />
+      return <FieldToMany {...{ noDataDisplayString, ...props }} />
     case consts.inputTypes.ONE_TO_ONE_TYPE:
       return <span>OneToOne</span>
     default:

--- a/src/table/Table.js
+++ b/src/table/Table.js
@@ -422,7 +422,8 @@ export const Table = ({
     return <div>...Loading</div>
   }
   if (!fromIndex && data.length === 0) {
-    return <div style={{ paddingBottom: '10px' }}>N/A</div>
+    const noDataDisplayString = R.pathOr('N/A', ['fields', parentFieldName, 'noDataDisplayString'], schema.getModel(parentModelName))
+    return <div style={{ paddingBottom: '10px' }}>{noDataDisplayString}</div>
   }
 
   const deletable = schema.isTableDeletable({

--- a/src/table/Table.js
+++ b/src/table/Table.js
@@ -422,8 +422,8 @@ export const Table = ({
     return <div>...Loading</div>
   }
   if (!fromIndex && data.length === 0) {
-    const noDataDisplayString = R.pathOr('N/A', ['fields', parentFieldName, 'noDataDisplayString'], schema.getModel(parentModelName))
-    return <div style={{ paddingBottom: '10px' }}>{noDataDisplayString}</div>
+    const noDataDisplayValue = schema.getNoDataDisplayValue({ modelName: parentModelName, fieldName: parentFieldName, node: parentNode, customProps })
+    return <div style={{ paddingBottom: '10px' }}>{noDataDisplayValue}</div>
   }
 
   const deletable = schema.isTableDeletable({


### PR DESCRIPTION
connected to https://github.com/autoinvent/conveyor-schema/pull/17

added a prop `noDataDisplayString` that allows user to customize the string that displays when a field has no data.