### PR TITLE
added a space before the detail component and the tab

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -51,21 +51,23 @@ const TabFields = ({
         })
 
   return (
-    <DetailFields {...{
-      schema,
-      modelName,
-      id,
-      node,
-      modalData,
-      path,
-      tableFields,
-      tooltipData,
-      editData,
-      descriptionList,
-      selectOptions,
-      tableView,
-      customProps
-    }} />
+    <div className='mt-3'>
+      <DetailFields {...{
+        schema,
+        modelName,
+        id,
+        node,
+        modalData,
+        path,
+        tableFields,
+        tooltipData,
+        editData,
+        descriptionList,
+        selectOptions,
+        tableView,
+        customProps
+      }} />
+    </div>
   )
 }
 


### PR DESCRIPTION
There was no space between the tab and the beginning of the detail component. This is atheistic only.