### PR TITLE
Fix extra columns being generated in the DeleteDetail tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 Add classNames to common components Issue #13
 Refactor, added NullComponent branched lists to own branches
 Move styling from inside react components to the css
+Fix extra columns being generated in the DeleteDetail tables
 
 ## Version 0.6.0
 

--- a/src/delete/DeleteDetail.js
+++ b/src/delete/DeleteDetail.js
@@ -40,6 +40,7 @@ const getRowFields = (schema, modelName, node, nodeOrder) => {
 
   return R.pipe(
     R.reject(val => val === undefined),
+    // Makes sure the row never has more columns than the header
     R.map(R.when(Array.isArray, R.join(" "))),
     R.flatten,
   )(fields)

--- a/src/delete/DeleteDetail.js
+++ b/src/delete/DeleteDetail.js
@@ -39,8 +39,9 @@ const getRowFields = (schema, modelName, node, nodeOrder) => {
   })
 
   return R.pipe(
+    R.reject(val => val === undefined),
+    R.map(R.when(Array.isArray, R.join(" "))),
     R.flatten,
-    R.reject(val => val === undefined)
   )(fields)
 }
 


### PR DESCRIPTION
This fix prevents extra columns from being generated in the delete modal tables when there are more row columns than header columns.