### PR TITLE
Render footer properly for chrome/firefox

### DIFF
--- a/src/table/Footer.js
+++ b/src/table/Footer.js
@@ -9,6 +9,7 @@ export const TFoot = ({
   fieldOrder,
   summary,
   fromIndex,
+  buttonColumnExists,
   customProps,
 }) => {
   const getSummaryPath = fieldName => fromIndex ? [modelName, fieldName] : [parentModelName, parentFieldName, fieldName]
@@ -45,7 +46,8 @@ export const TFoot = ({
             fromIndex,
             customProps,
             getSummaryPath,
-            checkFooterField
+            checkFooterField,
+            buttonColumnExists
           }}
         />
       </tr>
@@ -63,8 +65,12 @@ const ThFootList = ({
   fromIndex,
   customProps,
   getSummaryPath,
-  checkFooterField
+  checkFooterField,
+  buttonColumnExists
 }) => {
+  if (buttonColumnExists) {
+    fieldOrder.push(null)
+  }
   return fieldOrder.map((fieldName, idx) => {
     if (fromIndex === true) {
      if (

--- a/src/table/Table.js
+++ b/src/table/Table.js
@@ -357,7 +357,8 @@ const TRList = ({
   parentNode,
   fromIndex,
   customProps,
-  onEditCancel
+  onEditCancel,
+  buttonColumnExists
 }) => {
   return data.map((node, idx) => {
     const editable = schema.isRowEditable({
@@ -390,11 +391,7 @@ const TRList = ({
           customProps
         }}
       />
-      {showButtonColumn({
-        deletable,
-        editable: tableEditable,
-        detailField
-      }) && (
+      {buttonColumnExists && (
         <td key={`${node.id}-edit-delete`}>
           {
             <TableButtonCell
@@ -445,7 +442,8 @@ const TBody = ({
   selectOptions,
   parentNode,
   fromIndex,
-  customProps
+  customProps,
+  buttonColumnExists
 }) => {
   const actions = schema.getActions(modelName)
   const onEditCancel = R.path(['edit', 'onTableEditCancel'], actions)
@@ -472,7 +470,8 @@ const TBody = ({
           parentNode,
           fromIndex,
           customProps,
-          onEditCancel
+          onEditCancel,
+          buttonColumnExists
         }}
       />
     </tbody>
@@ -533,6 +532,7 @@ export const Table = ({
     fieldOrder,
     customProps
   })
+  const buttonColumnExists = showButtonColumn({ deletable, editable, detailField})
 
   return (
     <React.Fragment>
@@ -572,7 +572,8 @@ export const Table = ({
             tableEditable: editable,
             parentNode,
             fromIndex,
-            customProps
+            customProps,
+            buttonColumnExists
           }}
         />
         <Foot
@@ -585,6 +586,7 @@ export const Table = ({
             summary,
             fromIndex,
             customProps,
+            buttonColumnExists
           }}
         />
       </table>


### PR DESCRIPTION
For Issue #11 
- Fix issue where Chrome does not render an empty cell for footer row where edit/delete button column would be
- Added check at <TFoot> to render empty cell depending an edit/delete column exists