### PR TITLE
trigger search when the search page is loaded.

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -111,6 +111,15 @@ export const SearchPage = ({
       R.find(R.propEq('modelName', entry.modelName))(filters)
     )
   const history = useHistory()
+  const debouncedOnTriggerSearch = useCallback(
+    debounce((queryText) =>
+      handleSearchOnClick(queryText, onTriggerSearch, onBlur)
+    ),
+    []
+  )
+  if (searchText !== queryText) {
+    debouncedOnTriggerSearch(searchText)
+  }
   return (
     <div className="conv-search-page">
       <div


### PR DESCRIPTION
If you arrive at the search page by url, this will trigger the page to load the data.

closes item 2 of Routing to Search/ crashes the application #148
https://github.com/autoinvent/conveyor/issues/148