### PR TITLE
Search from url query param

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -119,8 +119,9 @@ export const SearchPage = ({
     ),
     []
   )
-  if (searchText !== queryText) {
+  if (entries === null) {
     debouncedOnTriggerSearch(searchText)
+    return 'Loading...'
   }
   const queryTextUri = encodeURIComponent(queryText)
   return (

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -111,6 +111,15 @@ export const SearchPage = ({
       R.find(R.propEq('modelName', entry.modelName))(filters)
     )
   const history = useHistory()
+  const debouncedOnTriggerSearch = useCallback(
+    debounce((queryText) =>
+      handleSearchOnClick(queryText, onTriggerSearch, onBlur)
+    ),
+    []
+  )
+  if (searchText !== queryText) {
+    debouncedOnTriggerSearch(searchText)
+  }
   return (
     <div className="conv-search-page">
       <div

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -63,7 +63,8 @@ const handleSearchOnEnter = (
   onBlur: CallableFunction
 ) => {
   if (evt.key === 'Enter' && queryText !== '') {
-    history.push(`/Search/${queryText}`)
+    const queryTextUri = encodeURIComponent(queryText)
+    history.push(`/Search?q=${queryTextUri}`)
     onTriggerSearch({ queryText, isOnSearchPage: true })
     onBlur()
   }
@@ -103,7 +104,8 @@ export const SearchPage = ({
   onTriggerSearch,
   onBlur
 }: SearchPageProps) => {
-  const searchText = location.pathname.split('/')[2]
+  const urlParams = new URLSearchParams(location.search)
+  const searchText = urlParams.get('q')
   const shouldShow = (entry: any) =>
     R.propOr(
       true,
@@ -120,6 +122,7 @@ export const SearchPage = ({
   if (searchText !== queryText) {
     debouncedOnTriggerSearch(searchText)
   }
+  const queryTextUri = encodeURIComponent(queryText)
   return (
     <div className="conv-search-page">
       <div
@@ -143,7 +146,7 @@ export const SearchPage = ({
           }}
         />
         <Link
-          to={`/Search/${queryText}`}
+          to={`/Search?q=${queryTextUri}`}
           onClick={() =>
             handleSearchOnClick(queryText, onTriggerSearch, onBlur)
           }
@@ -225,6 +228,7 @@ export const QuickSearch = ({
     debounce((queryText) => onTriggerSearch({ queryText }), 500),
     []
   )
+  const queryTextUri = encodeURIComponent(queryText)
   return (
     <div
       className="conv-search"
@@ -275,7 +279,7 @@ export const QuickSearch = ({
         </div>
       )}
       <Link
-        to={`/Search/${queryText}`}
+        to={`/Search?q=${queryTextUri}`}
         onClick={() => {
           handleSearchOnClick(queryText, onTriggerSearch, onBlur)
           debouncedOnTriggerSearch.cancel()


### PR DESCRIPTION
Based on:  https://github.com/autoinvent/conveyor/pull/154
Closing #148 

REQUIRES:  https://github.com/autoinvent/conveyor-redux/pull/77

Because the query is moved from the path to the search params, you will have to change this line:
`<Route exact path="/Search/:searchText" component={SearchPageContainer} />`
to
`<Route exact path="/Search" component={SearchPageContainer} />`

in the running application