### PR TITLE
Using browser back button on create page issue

### DIFF
--- a/src/CreateButton.tsx
+++ b/src/CreateButton.tsx
@@ -7,14 +7,14 @@ import { Link } from 'react-router-dom'
  * @param to
  * @return Rendered React Component
  */
-type CreateButtonProps = { onClick: any; to: string }
-const CreateButton = ({ onClick, to }: CreateButtonProps) => (
+type CreateButtonProps = { onClick: any; to: string; fromIndex: boolean }
+const CreateButton = ({ onClick, to, fromIndex }: CreateButtonProps) => (
   <Link
     to={`/Create/${to}`}
     onClick={onClick}
     className="conv-create-button"
     role="button"
-    replace
+    replace={!fromIndex}
   >
     Create
   </Link>

--- a/src/CreateButton.tsx
+++ b/src/CreateButton.tsx
@@ -7,14 +7,14 @@ import { Link } from 'react-router-dom'
  * @param to
  * @return Rendered React Component
  */
-type CreateButtonProps = { onClick: any; to: string; fromIndex: boolean }
-const CreateButton = ({ onClick, to, fromIndex }: CreateButtonProps) => (
+type CreateButtonProps = { onClick: any; to: string; replaceEntry: boolean }
+const CreateButton = ({ onClick, to, replaceEntry }: CreateButtonProps) => (
   <Link
     to={`/Create/${to}`}
     onClick={onClick}
     className="conv-create-button"
     role="button"
-    replace={!fromIndex}
+    replace={replaceEntry}
   >
     Create
   </Link>

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -344,7 +344,9 @@ export const DetailCreateButton = ({
       targetInverseFieldName,
       node
     })
-  return <CreateButton {...{ onClick, to: targetModelName }} />
+  return (
+    <CreateButton {...{ onClick, to: targetModelName, fromIndex: false }} />
+  )
 }
 
 type DefaultDetailTableTitleWrapperProps = {

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -345,7 +345,7 @@ export const DetailCreateButton = ({
       node
     })
   return (
-    <CreateButton {...{ onClick, to: targetModelName, fromIndex: false }} />
+    <CreateButton {...{ onClick, to: targetModelName, replaceEntry: false }} />
   )
 }
 

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -72,7 +72,7 @@ export const DefaultIndexTitle = ({
           <FilterModalButton {...{ modelName, filtersAreActive }} />
         )}
         {creatable && (
-          <CreateButton {...{ onClick, to: modelName, fromIndex: true }} />
+          <CreateButton {...{ onClick, to: modelName, replaceEntry: false }} />
         )}
       </div>
     </div>
@@ -253,7 +253,7 @@ const Index = ({
             {...{
               onClick: () => onCreateClick({ modelName }),
               to: modelName,
-              fromIndex: true
+              replaceEntry: false
             }}
           />
         </h1>

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -71,7 +71,9 @@ export const DefaultIndexTitle = ({
         {filterable && (
           <FilterModalButton {...{ modelName, filtersAreActive }} />
         )}
-        {creatable && <CreateButton {...{ onClick, to: modelName }} />}
+        {creatable && (
+          <CreateButton {...{ onClick, to: modelName, fromIndex: true }} />
+        )}
       </div>
     </div>
   )
@@ -250,7 +252,8 @@ const Index = ({
           <CreateButton
             {...{
               onClick: () => onCreateClick({ modelName }),
-              to: modelName
+              to: modelName,
+              fromIndex: true
             }}
           />
         </h1>

--- a/src/form/Input.tsx
+++ b/src/form/Input.tsx
@@ -36,7 +36,8 @@ export const relationshipLabelFactory = ({
         <CreateButton
           {...{
             onClick,
-            to: relModelName
+            to: relModelName,
+            fromIndex: false
           }}
         />
       )}

--- a/src/form/Input.tsx
+++ b/src/form/Input.tsx
@@ -37,7 +37,7 @@ export const relationshipLabelFactory = ({
           {...{
             onClick,
             to: relModelName,
-            fromIndex: false
+            replaceEntry: true
           }}
         />
       )}


### PR DESCRIPTION
Modified the create button to create a new layer in the router history stack.
This should fix the issue with hitting browser back button while on the page for creating entry.
There is now a side effect of the top two entries of the history stack to both be index pages.
May need to revisit and make additional adjustments.