### PR TITLE
change datetime to datetime-local and clean up DateTime objects with moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "GraphiQL for magql",
   "license": "BlueOak-1.0.0",
   "author": "Moebius Solutions",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "./dist/conveyor.umd.js",
   "module": "./dist/conveyor.mjs",
   "types": "./dist/index.d.ts",
@@ -37,6 +39,7 @@
     "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.3.0",
     "bootswatch": "^5.3.0",
+    "moment": "^2.30.1",
     "react-bootstrap": "^2.8.0",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.45.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   bootswatch:
     specifier: ^5.3.0
     version: 5.3.0
+  moment:
+    specifier: ^2.30.1
+    version: 2.30.1
   react-bootstrap:
     specifier: ^2.8.0
     version: 2.8.0(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
@@ -3505,6 +3508,10 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.1.2
     dev: true
+
+  /moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+    dev: false
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}

--- a/src/components/ModelForm/ModelFormValue.tsx
+++ b/src/components/ModelForm/ModelFormValue.tsx
@@ -7,7 +7,7 @@ import ModelNav from '../ModelNav';
 import Checkbox from '../commons/Checkbox';
 import { InputTypes } from '../commons/FlexibleInput';
 import { Card } from 'react-bootstrap';
-
+import DateTime from '../commons/DateTime';
 interface ModelFormValueProps extends BaseProps {
   modelName: string;
   fields: string[];
@@ -59,6 +59,8 @@ const ModelFormValue = ({
     );
   } else if (type === InputTypes.BOOLEAN) {
     displayData = <Checkbox value={currData} disabled={true} />;
+  } else if (type === InputTypes.DATETIME) {
+    displayData = <DateTime date={currData} />;
   }
 
   return (

--- a/src/components/commons/DateTime.tsx
+++ b/src/components/commons/DateTime.tsx
@@ -1,0 +1,14 @@
+import { BaseProps } from '../../types';
+import moment from 'moment';
+
+interface DateTimeProps extends BaseProps {
+  date?: Date;
+}
+
+const DateTime = ({ date }: DateTimeProps) => {
+  console.log(moment.version);
+  // Process the date as needed
+  return moment(date).format('MM / DD / YYYY hh:mm:ss A');
+};
+
+export default DateTime;

--- a/src/components/commons/FlexibleInput.tsx
+++ b/src/components/commons/FlexibleInput.tsx
@@ -10,7 +10,7 @@ export enum InputTypes {
   NUMBER = 'number',
   BOOLEAN = 'checkbox',
   SELECT = 'select',
-  DATETIME = 'date_time',
+  DATETIME = 'datetime-local',
 }
 export interface FlexibleInputProps extends BaseProps {
   type: InputTypes;


### PR DESCRIPTION
These commits should fix both issue 16 and issue 17. The date picker widget will display when editing the created_at field, and when the object is created/saved the datetime is displayed in the same format as the date picker widget (MM/DD/YYYY hh:mm:ss A). 