### PR TITLE
Better display value for references

### DIFF
--- a/src/components/ModelDetail/ModelDetail.tsx
+++ b/src/components/ModelDetail/ModelDetail.tsx
@@ -44,6 +44,20 @@ const ModelDetail = ({
   const { primaryKey, secondaryKeys } = useContext(ConveyorContext);
   const keyFallbacks = [primaryKey].concat(secondaryKeys ?? []);
   const availableKeys = getAvailableKeys(fields, keyFallbacks);
+  const displayValue = () => {
+    // Check for 'display_value' field
+    if (fields.includes('display_value')) {
+      return 'display_value';
+    }
+    // Check for 'name' field
+    else if (fields.includes('name')) {
+      return 'name';
+    }
+    // Default to the first available secondary key
+    else {
+      return availableKeys.at(1);
+    }
+  };
   const actionType = GQLQueryAction.MODEL_ITEM;
   const action = getGQLAction(actionType, modelName);
   const document = getGQLDocument(
@@ -91,7 +105,7 @@ const ModelDetail = ({
                     <ModelNav modelName={modelName}>
                       <Card.Link>{humanizeText(modelName)}</Card.Link>
                     </ModelNav>
-                    :{modelData[availableKeys.at(1) ?? primaryKey]}
+                    : {modelData[displayValue() ?? primaryKey]}
                   </>
                 )}
               </h2>

--- a/src/components/ModelForm/ModelFormValue.tsx
+++ b/src/components/ModelForm/ModelFormValue.tsx
@@ -33,6 +33,20 @@ const ModelFormValue = ({
   const keyFallbacks = [primaryKey].concat(secondaryKeys ?? []);
   if (related) {
     const availableKeys = getAvailableKeys(related.fields ?? [], keyFallbacks);
+    const displayRelatedValue = () => {
+      // Check for 'display_value' related field
+      if (related.fields?.includes('display_value')) {
+        return 'display_value';
+      }
+      // Check for 'name' related field
+      else if (related.fields?.includes('name')) {
+        return 'name';
+      }
+      // Default to the first available secondary key
+      else {
+        return availableKeys.at(1);
+      }
+    };
     if (!related.many) {
       displayData = displayData ? [displayData] : [];
     }
@@ -45,7 +59,7 @@ const ModelFormValue = ({
           modelId={val[primaryKey]}
         >
           <Card.Link>
-            {val?.[availableKeys.at(1) ?? primaryKey]}
+            {val?.[displayRelatedValue() ?? primaryKey]}
             {index !== displayData?.length - 1 && ','}
           </Card.Link>
         </ModelNav>


### PR DESCRIPTION
The title of the `modelDetail` page, as well as related fields will look for a field called `display_value` first, then `name`, then the first available secondary key (the first unique field other than the `primaryKey,` for example: `User` displays the unique field `username`). Finally if none of the aforementioned fields exist, and there are no secondary keys, we fall back to the `primaryKey` which by default is `id`.