### PR TITLE
ModelDelete modal

### DIFF
--- a/src/ModelDelete/ModelDelete.stories.tsx
+++ b/src/ModelDelete/ModelDelete.stories.tsx
@@ -1,0 +1,354 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ModelDelete } from './ModelDelete';
+
+const meta = {
+    title: 'Model/ModelDelete/ModelDelete',
+    component: ModelDelete,
+    args: {
+        affected: [],
+        prevented: [],
+        deleted: [],
+    }
+} satisfies Meta<typeof ModelDelete>
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Affected: Story = {
+    args: {
+        affected: [{
+            type: 'Noir',
+            id: 75,
+            value: 'Chinatown',
+            extra: 'Jack Nicholson'
+        },
+        {
+            type: 'Comedy',
+            id: 4353,
+            value: 'The Hangover',
+            extra: 'Bradley Cooper'
+        },
+        {
+            type: 'Horror',
+            id: 8543,
+            value: 'Hereditary',
+            extra: 'Ari Aster'
+        },
+        {
+            type: 'Horror',
+            id: '343c',
+            value: 'The Thing',
+            extra: 'John Carpenter'
+        },
+        {
+            type: 'Action/Thriller',
+            id: 221,
+            value: 'Sicario',
+            extra: 'Emily Blunt'
+        }],
+        prevented: [],
+        deleted: [],
+    }
+};
+
+export const Prevented: Story = {
+    args: {
+        affected: [],
+        prevented: [{
+            type: 'Thriller',
+            id: 69,
+            value: 'Alien',
+            extra: 'Sigourney Weaver'
+        }],
+        deleted: [],
+    }
+};
+
+export const Deleted: Story = {
+    args: {
+        affected: [],
+        prevented: [],
+        deleted: [{
+            type: 'Noir',
+            id: 75,
+            value: 'Blood Simple',
+            extra: 'Frances McDormand'
+        },
+        {
+            type: 'Sci-Fi',
+            id: 4353,
+            value: 'Dune: Part Two',
+            extra: 'Denis Villeneuve'
+        }]
+    }
+};
+
+export const AllConflicts: Story = {
+    args: {
+        affected: [{
+            type: 'Noir',
+            id: 75,
+            value: 'Chinatown',
+            extra: 'Jack Nicholson'
+        },
+        {
+            type: 'Comedy',
+            id: 4353,
+            value: 'The Hangover',
+            extra: 'Bradley Cooper'
+        }],
+        prevented: [{
+            type: 'Thriller',
+            id: 69,
+            value: 'Alien',
+            extra: 'Sigourney Weaver'
+        }],
+        deleted: [{
+            type: 'Noir',
+            id: 75,
+            value: 'Blood Simple',
+            extra: 'Frances McDormand'
+        },
+        {
+            type: 'Sci-Fi',
+            id: 4353,
+            value: 'Dune: Part Two',
+            extra: 'Denis Villeneuve'
+        }],
+    }
+};
+
+export const NoConflicts: Story = {
+    args: {
+        affected: [],
+        prevented: [],
+        deleted: [],
+    }
+}
+
+export const DataOverload: Story = {
+    args: {
+        affected: [
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            }
+        ],
+        prevented: [
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            }
+        ],
+        deleted: [
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            },
+            {
+                type: 'Noir',
+                id: 75,
+                value: 'Blood Simple',
+                extra: 'Frances McDormand'
+            },
+            {
+                type: 'Sci-Fi',
+                id: 4353,
+                value: 'Dune: Part Two',
+                extra: 'Denis Villeneuve'
+            }
+        ]
+    }
+}

--- a/src/ModelDelete/ModelDelete.tsx
+++ b/src/ModelDelete/ModelDelete.tsx
@@ -1,0 +1,119 @@
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader } from '@/lib/components/ui/card';
+import { ScrollArea } from '@/lib/components/ui/scroll-area';
+import type { CheckDeleteResult } from '@/types';
+
+export const ModelDelete = ({ affected, prevented, deleted }: CheckDeleteResult) => {
+
+    const message = (prevented && prevented.length > 0) ? 
+    <span className="text-red-500">
+        You are currently not permitted to make these deletions due to resulting conflicts. Please review them and try again.
+    </span> :
+    <span>
+        Are you sure you want to confirm these deletions?
+    </span> ;
+
+    const noEffects = ((affected === undefined) || affected.length === 0) 
+    && ((prevented === undefined) || prevented.length === 0) 
+    && ((deleted === undefined) || deleted.length === 0);
+
+    return (
+        <div className='flex h-screen items-center justify-center'>
+            <Card className='max-h-fit max-w-md'>
+                <CardHeader>
+                    <CardDescription className="text-lg">Deletion Conflicts</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {noEffects && (
+                        <span>
+                            There are no conflicts related to your deletions!
+                        </span>
+                    )}
+                    {(affected && affected.length > 0) &&
+                    (<div className="pb-2">
+                        The following models will be affected by your deletions:
+                        {affected.length > 4 ? (
+                        <ScrollArea className="max-h-20 rounded-sm bg-slate-50">
+                            <ul>
+                                {affected.map((e) => (
+                                    (<li key={e.value} className="p-1 font-bold">{e.value}</li>)
+                                ))}
+                            </ul>
+                        </ScrollArea>
+                        ) :
+                        (
+                        <div>
+                            {affected.map((e) => (
+                                (<span key={e.value} className="p-1 px-2 font-bold">{e.value}</span>)
+                            ))}
+                        </div>
+                        )}
+                    </div>
+                    )}
+                    {(prevented && prevented.length > 0) &&
+                    (<div className="pb-2">
+                        The following models are preventing your deletions:
+                        {prevented.length > 4 ? (
+                        <ScrollArea className="max-h-20 rounded-sm bg-slate-50">
+                            <ul>
+                                {prevented.map((e) => (
+                                    (<li key={e.value} className="p-1 font-bold">{e.value}</li>)
+                                ))}
+                            </ul>
+                        </ScrollArea>
+                        ) :
+                        (
+                        <div>
+                            {prevented.map((e) => (
+                                (<span key={e.value} className="p-1 px-2 font-bold">{e.value}</span>)
+                            ))}
+                        </div>
+                        )}
+                    </div>
+                    )}
+                    {(deleted && deleted.length > 0) &&
+                    (<div className="pb-2">
+                        The following models will be deleted by your deletions:
+                        {deleted.length > 4 ? (
+                        <ScrollArea className="max-h-20 rounded-sm bg-slate-50">
+                            <ul>
+                                {deleted.map((e) => (
+                                    (<li key={e.value} className="p-1 font-bold">{e.value}</li>)
+                                ))}
+                            </ul>
+                        </ScrollArea>
+                        ) :
+                        (
+                        <div>
+                            {deleted.map((e) => (
+                                (<span key={e.value} className="p-1 px-2 font-bold">{e.value}</span>)
+                            ))}
+                        </div>
+                        )}
+                    </div>
+                    )}
+                    <div className="py-4">
+                        {message}
+                    </div>
+                    {(prevented && prevented.length > 0) ? (
+                        <div className="flex justify-end">
+                            <Button variant="ghost">
+                                OK
+                            </Button>
+                        </div>
+                    ) :
+                    (
+                        <div className="flex justify-end">
+                            <Button variant="ghost" className="mx-2">
+                                Cancel
+                            </Button>
+                            <Button variant="destructive" className="ml-2">
+                                Confirm
+                            </Button>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+};

--- a/src/ModelDelete/index.ts
+++ b/src/ModelDelete/index.ts
@@ -1,0 +1,1 @@
+export * from './ModelDelete';


### PR DESCRIPTION
This introduces a check delete modal which would typically be presented to the user upon attempting to delete some instance of data. It is given three lists of affected, prevented and deleted models respectively which each describe chunks of data which would be altered somehow through the deletion, and these resulting changes are presented to the user with appropriate action buttons. Component is based on shadcn <Card>.