### PR TITLE
Column Visibility TableGuide Story

### DIFF
--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -12,7 +12,8 @@ const meta = {
       { firstname: 'Robert', lastname: 'Hernandez', username: 'robxbob' },
       { firstname: 'Jeffrey', lastname: 'Davis', username: 'itechify' },
       { firstname: 'Aidan', lastname: 'Glenister', username: 'apglenister' },
-      { firstname: 'Conner', lastname: 'MacGray', username: 'cmacgray14'},
+      { firstname: 'Conner', lastname: 'MacGray', username: 'cmacgray14' },
+      { firstname: 'Krista', lastname: 'Strucke', username: 'kurikurichan' },
     ],
   },
 } satisfies Meta<typeof Table>;

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -9,9 +9,10 @@ const meta = {
   args: {
     columnIds: ['firstname', 'lastname', 'username'],
     data: [
-      { firstname: 'Robert', lastname: 'Hernandez' },
-      { firstname: 'Jeffrey', lastname: 'Davis' },
-      { firstname: 'Aidan', lastname: 'Glenister' },
+      { firstname: 'Robert', lastname: 'Hernandez', username: 'robxbob' },
+      { firstname: 'Jeffrey', lastname: 'Davis', username: 'itechify' },
+      { firstname: 'Aidan', lastname: 'Glenister', username: 'apglenister' },
+      { firstname: 'Conner', lastname: 'MacGray', username: 'cmacgray14'},
     ],
   },
 } satisfies Meta<typeof Table>;

--- a/src/Table/TableGuides.stories.tsx
+++ b/src/Table/TableGuides.stories.tsx
@@ -6,6 +6,15 @@ import { Button } from '@/lib/components/ui/button';
 
 import { Table } from './Table';
 import TableStoryMeta from './Table.stories';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/lib/components/ui/card';
+import { Checkbox } from '@/lib/components/ui/checkbox';
+import { Label } from '@/lib/components/ui/label';
+import { Separator } from '@/lib/components/ui/separator';
 
 const meta = {
   title: 'Commons/Table/TableGuide',
@@ -49,72 +58,58 @@ export const ColumnReordering: Story = {
 };
 
 export const ColumnVisibility: Story = {
-  render: (props) => {
-    const givenColumns = props.columnIds;
-    const [visibleColumns, setVisibleColumns] = useState<boolean []>(Array(givenColumns.length).fill(true));
-    // const [visibleColumns, setVisibleColumns] = useState<string []>(givenColumns); //initialize object with columns
+  render: ({ columnIds, ...props }) => {
+    const [columnVisibility, setColumnVisibility] = useState(
+      Object.fromEntries(columnIds.map((columnId) => [columnId, true])),
+    );
+    const isAllColumnsVisible = Object.values(columnVisibility).every((v) => v);
 
-    function isColumnVisible(column: string): boolean {
-      return visibleColumns[givenColumns.indexOf(column)];
+    const toggleColumnVisibility = (columnId: string) => () =>
+      setColumnVisibility((oldColumnVisibility) =>
+        Object.assign({}, oldColumnVisibility, {
+          [columnId]: !oldColumnVisibility[columnId],
+        }),
+      );
+    const toggleAllColumnVisibility = () => {
+      setColumnVisibility(
+        Object.fromEntries(
+          columnIds.map((columnId) => [columnId, !isAllColumnsVisible]),
+        ),
+      );
     };
-
-    function allColumnsVisible(): boolean {
-      return visibleColumns.every((b) => b === true);
-    };
-
-    function handleCheckboxChange(column: string) {
-      const newVisibleColumns = [...visibleColumns];
-      if (isColumnVisible(column) === true) {
-        newVisibleColumns[givenColumns.indexOf(column)] = false;
-      }
-      else {
-        newVisibleColumns[givenColumns.indexOf(column)] = true;
-      }
-      setVisibleColumns(newVisibleColumns);
-    };
-
-    function handleToggleAllChange() {
-      if (allColumnsVisible() === true) {
-        setVisibleColumns(Array(givenColumns.length).fill(false));
-      }
-      else {
-        setVisibleColumns(Array(givenColumns.length).fill(true));
-      }
-    }
 
     return (
       <>
-        <div className='inline-block rounded border border-black shadow'>
-          <div className='border-black border-b px-1'>
-            <label>
-              <input
-                {...{
-                  type: 'checkbox',
-                  checked: allColumnsVisible(),
-                  onChange: () => handleToggleAllChange(),
-                }}
-              />{' '}
-              Toggle All
-            </label>
-          </div>
-          {givenColumns.map((column) => {
-            return ( 
-              <div key={column} className="px-1">
-                <label>
-                  <input
-                    {...{
-                      type: 'checkbox',
-                      checked: isColumnVisible(column),
-                      onChange: () => handleCheckboxChange(column)
-                    }}
-                  />{' '}
-                  {column}
-                </label>
+        <Card className="w-64">
+          <CardHeader>
+            <CardTitle className="text-center">Column Visibility</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="toggle-all"
+                checked={isAllColumnsVisible}
+                onCheckedChange={toggleAllColumnVisibility}
+              />
+              <Label htmlFor="toggle-all">Toggle All</Label>
+            </div>
+            <Separator />
+            {columnIds.map((columnId) => (
+              <div key={columnId} className="flex items-center gap-2">
+                <Checkbox
+                  id={columnId}
+                  checked={columnVisibility[columnId]}
+                  onCheckedChange={toggleColumnVisibility(columnId)}
+                />
+                <Label htmlFor={columnId}>{columnId}</Label>
               </div>
-            );
-          })}
-        </div>
-        <Table {...props} columnIds={givenColumns.filter((column, i) => visibleColumns[i] === true)}/>
+            ))}
+          </CardContent>
+        </Card>
+        <Table
+          {...props}
+          columnIds={columnIds.filter((columnId) => columnVisibility[columnId])}
+        />
       </>
     );
   },

--- a/src/Table/TableGuides.stories.tsx
+++ b/src/Table/TableGuides.stories.tsx
@@ -47,3 +47,75 @@ export const ColumnReordering: Story = {
     );
   },
 };
+
+export const ColumnVisibility: Story = {
+  render: (props) => {
+    const givenColumns = props.columnIds;
+    const [visibleColumns, setVisibleColumns] = useState<boolean []>(Array(givenColumns.length).fill(true));
+    // const [visibleColumns, setVisibleColumns] = useState<string []>(givenColumns); //initialize object with columns
+
+    function isColumnVisible(column: string): boolean {
+      return visibleColumns[givenColumns.indexOf(column)];
+    };
+
+    function allColumnsVisible(): boolean {
+      return visibleColumns.every((b) => b === true);
+    };
+
+    function handleCheckboxChange(column: string) {
+      const newVisibleColumns = [...visibleColumns];
+      if (isColumnVisible(column) === true) {
+        newVisibleColumns[givenColumns.indexOf(column)] = false;
+      }
+      else {
+        newVisibleColumns[givenColumns.indexOf(column)] = true;
+      }
+      setVisibleColumns(newVisibleColumns);
+    };
+
+    function handleToggleAllChange() {
+      if (allColumnsVisible() === true) {
+        setVisibleColumns(Array(givenColumns.length).fill(false));
+      }
+      else {
+        setVisibleColumns(Array(givenColumns.length).fill(true));
+      }
+    }
+
+    return (
+      <>
+        <div className='inline-block rounded border border-black shadow'>
+          <div className='border-black border-b px-1'>
+            <label>
+              <input
+                {...{
+                  type: 'checkbox',
+                  checked: allColumnsVisible(),
+                  onChange: () => handleToggleAllChange(),
+                }}
+              />{' '}
+              Toggle All
+            </label>
+          </div>
+          {givenColumns.map((column) => {
+            return ( 
+              <div key={column} className="px-1">
+                <label>
+                  <input
+                    {...{
+                      type: 'checkbox',
+                      checked: isColumnVisible(column),
+                      onChange: () => handleCheckboxChange(column)
+                    }}
+                  />{' '}
+                  {column}
+                </label>
+              </div>
+            );
+          })}
+        </div>
+        <Table {...props} columnIds={givenColumns.filter((column, i) => visibleColumns[i] === true)}/>
+      </>
+    );
+  },
+};


### PR DESCRIPTION
Adds a column visibility feature demonstrated through the TableGuide story named ColumnVisibility. Includes a checkbox with each column ID that can be used to optionally show or hide each column of the table. Preserves order upon checking/unchecking