### PR TITLE
Creatable select

### DIFF
--- a/src/BasicInputs/CreatableSelectInput.tsx
+++ b/src/BasicInputs/CreatableSelectInput.tsx
@@ -1,14 +1,19 @@
 import type { FormControlChildProps } from '@/Form';
 import { cn } from '@/lib/utils';
-import { type ComponentProps, type ComponentPropsWithoutRef, type ElementRef, forwardRef,  type PropsWithoutRef } from 'react';
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type PropsWithoutRef,
+  forwardRef,
+} from 'react';
 import Creatable from 'react-select/creatable';
 
 export const CreatableSelectInput = forwardRef<
   ElementRef<typeof Creatable>,
   PropsWithoutRef<FormControlChildProps> &
-  ComponentPropsWithoutRef<typeof Creatable>
+    ComponentPropsWithoutRef<typeof Creatable>
 >(({ disabled, className, ...props }, ref) => {
-
   const defaultStyling: ComponentProps<typeof Creatable>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
@@ -97,17 +102,13 @@ export const CreatableSelectInput = forwardRef<
 
   return (
     <div
-    className={cn(
-      'rounded-md focus-within:outline focus-within:outline-2 focus-within:outline-offset-2',
-      disabled && 'cursor-not-allowed',
-      className,
-    )}
+      className={cn(
+        'rounded-md focus-within:outline focus-within:outline-2 focus-within:outline-offset-2',
+        disabled && 'cursor-not-allowed',
+        className,
+      )}
     >
-      <Creatable 
-        unstyled 
-        classNames={defaultStyling}
-        {...props}
-      />
+      <Creatable unstyled classNames={defaultStyling} {...props} />
     </div>
-  )
+  );
 });

--- a/src/BasicInputs/CreatableSelectInput.tsx
+++ b/src/BasicInputs/CreatableSelectInput.tsx
@@ -1,21 +1,15 @@
-import {
-  type ComponentProps,
-  type ComponentPropsWithoutRef,
-  type ElementRef,
-  type PropsWithoutRef,
-  forwardRef,
-} from 'react';
-import Select from 'react-select';
-
 import type { FormControlChildProps } from '@/Form';
 import { cn } from '@/lib/utils';
+import { type ComponentProps, type ComponentPropsWithoutRef, type ElementRef, forwardRef,  type PropsWithoutRef } from 'react';
+import Creatable from 'react-select/creatable';
 
-export const SelectInput = forwardRef<
-  ElementRef<typeof Select>,
+export const CreatableSelectInput = forwardRef<
+  ElementRef<typeof Creatable>,
   PropsWithoutRef<FormControlChildProps> &
-    ComponentPropsWithoutRef<typeof Select>
+  ComponentPropsWithoutRef<typeof Creatable>
 >(({ disabled, className, ...props }, ref) => {
-  const defaultStyling: ComponentProps<typeof Select>['classNames'] = {
+
+  const defaultStyling: ComponentProps<typeof Creatable>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
         isFocused ? 'text-muted-foreground' : 'text-foreground',
@@ -103,20 +97,17 @@ export const SelectInput = forwardRef<
 
   return (
     <div
-      className={cn(
-        'rounded-md focus-within:outline focus-within:outline-2 focus-within:outline-offset-2',
-        disabled && 'cursor-not-allowed',
-        className,
-      )}
+    className={cn(
+      'rounded-md focus-within:outline focus-within:outline-2 focus-within:outline-offset-2',
+      disabled && 'cursor-not-allowed',
+      className,
+    )}
     >
-      <Select
-        ref={ref}
-        unstyled
+      <Creatable 
+        unstyled 
         classNames={defaultStyling}
-        menuPortalTarget={document.body}
-        isDisabled={disabled}
         {...props}
       />
     </div>
-  );
+  )
 });

--- a/src/BasicInputs/index.ts
+++ b/src/BasicInputs/index.ts
@@ -3,5 +3,6 @@ export * from './DatetimeInput';
 export * from './NumberInput';
 export * from './SelectInput';
 export * from './StringInput';
+export * from './CreatableSelectInput';
 
 export * from './ModelItemInput';

--- a/src/BasicInputs/stories/CreatableSelectInput.stories.tsx
+++ b/src/BasicInputs/stories/CreatableSelectInput.stories.tsx
@@ -1,10 +1,10 @@
-import  { CreatableSelectInput } from '../CreatableSelectInput';
 import type { Meta, StoryObj } from '@storybook/react';
+import { CreatableSelectInput } from '../CreatableSelectInput';
 
 const meta = {
-    title: 'Commons/Inputs',
-    component: CreatableSelectInput,
-    tags: ['autodocs'],
+  title: 'Commons/Inputs',
+  component: CreatableSelectInput,
+  tags: ['autodocs'],
 } satisfies Meta<typeof CreatableSelectInput>;
 export default meta;
 
@@ -22,7 +22,7 @@ export const BasicUsage: Story = {
       { value: 'harmony', label: 'Harmony' },
       { value: 'puzzle', label: 'Puzzle' },
       { value: 'symphony', label: 'Symphony' },
-      { value: 'labyrinth', label: 'Labyrinth' }
-    ]
-  }
+      { value: 'labyrinth', label: 'Labyrinth' },
+    ],
+  },
 };

--- a/src/BasicInputs/stories/CreatableSelectInput.stories.tsx
+++ b/src/BasicInputs/stories/CreatableSelectInput.stories.tsx
@@ -1,0 +1,28 @@
+import  { CreatableSelectInput } from '../CreatableSelectInput';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+    title: 'Commons/Inputs',
+    component: CreatableSelectInput,
+    tags: ['autodocs'],
+} satisfies Meta<typeof CreatableSelectInput>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const BasicUsage: Story = {
+  args: {
+    options: [
+      { value: 'apple', label: 'Apple' },
+      { value: 'mountain', label: 'Mountain' },
+      { value: 'ocean', label: 'Ocean' },
+      { value: 'whisper', label: 'Whisper' },
+      { value: 'butterfly', label: 'Butterfly' },
+      { value: 'galaxy', label: 'Galaxy' },
+      { value: 'harmony', label: 'Harmony' },
+      { value: 'puzzle', label: 'Puzzle' },
+      { value: 'symphony', label: 'Symphony' },
+      { value: 'labyrinth', label: 'Labyrinth' }
+    ]
+  }
+};


### PR DESCRIPTION
Adds the CreatableSelectInput component based off of <Creatable/> by react-select, exports it for use and creates a basic story demonstrating its functionality. Styled identically to the original SelectInput component. 