### PR TITLE
TS: Select Options

### DIFF
--- a/src/BasicInputs/CreatableSelectInput.tsx
+++ b/src/BasicInputs/CreatableSelectInput.tsx
@@ -13,7 +13,7 @@ export const CreatableSelectInput = forwardRef<
   ElementRef<typeof Creatable>,
   PropsWithoutRef<FormControlChildProps> &
     ComponentPropsWithoutRef<typeof Creatable>
->(({ disabled, className, ...props }, ref) => {
+>(({ disabled, className, selectoptions, options, ...props }, ref) => {
   const defaultStyling: ComponentProps<typeof Creatable>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
@@ -108,7 +108,7 @@ export const CreatableSelectInput = forwardRef<
         className,
       )}
     >
-      <Creatable unstyled classNames={defaultStyling} {...props} />
+      <Creatable unstyled classNames={defaultStyling} {...props} options={options ?? selectoptions} />
     </div>
   );
 });

--- a/src/BasicInputs/CreatableSelectInput.tsx
+++ b/src/BasicInputs/CreatableSelectInput.tsx
@@ -108,7 +108,12 @@ export const CreatableSelectInput = forwardRef<
         className,
       )}
     >
-      <Creatable unstyled classNames={defaultStyling} {...props} options={options ?? selectoptions} />
+      <Creatable
+        unstyled
+        classNames={defaultStyling}
+        {...props}
+        options={options ?? selectoptions}
+      />
     </div>
   );
 });

--- a/src/BasicInputs/ModelItemInput.tsx
+++ b/src/BasicInputs/ModelItemInput.tsx
@@ -9,7 +9,7 @@ import { SelectInput } from './SelectInput';
 export const ModelItemInput = forwardRef<
   ElementRef<typeof SelectInput>,
   ComponentPropsWithoutRef<typeof SelectInput>
->(({ value, onChange, ...selectInputProps }, ref) => {
+>(({ value, onChange, selectoptions, options, ...selectInputProps }, ref) => {
   return (
     <SelectInput
       ref={ref}
@@ -17,6 +17,7 @@ export const ModelItemInput = forwardRef<
       onChange={(newValue) =>
         onChange?.({ id: newValue.value, _display_value: newValue.label })
       }
+      options={options ?? selectoptions}
       {...selectInputProps}
     />
   );

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -14,7 +14,7 @@ export const SelectInput = forwardRef<
   ElementRef<typeof Select>,
   PropsWithoutRef<FormControlChildProps> &
     ComponentPropsWithoutRef<typeof Select>
->(({ disabled, className, ...props }, ref) => {
+>(({ disabled, className, selectoptions, options, ...props }, ref) => {
   const defaultStyling: ComponentProps<typeof Select>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
@@ -115,6 +115,7 @@ export const SelectInput = forwardRef<
         classNames={defaultStyling}
         menuPortalTarget={document.body}
         isDisabled={disabled}
+        options={options ?? selectoptions}
         {...props}
       />
     </div>

--- a/src/Form/FormControl.tsx
+++ b/src/Form/FormControl.tsx
@@ -11,7 +11,7 @@ import type { SelectOption } from '@/types';
 import { useFormStore } from './useFormStore';
 
 export interface FormControlProps extends Omit<UseControllerProps, 'control'> {
-  options?: SelectOption[];
+  selectoptions?: SelectOption[];
   children: ReactNode;
 }
 
@@ -22,12 +22,12 @@ export interface FormControlChildProps
   'aria-describedby'?: string;
   'aria-invalid'?: boolean;
   'aria-disabled'?: boolean;
-  options?: SelectOption[];
+  selectoptions?: SelectOption[];
 }
 
 export const FormControl = ({
   name,
-  options,
+  selectoptions,
   children,
   ...controllerProps
 }: FormControlProps) => {
@@ -44,7 +44,7 @@ export const FormControl = ({
   const slotProps = {
     ...field,
     disabled: isSubmitting,
-    options,
+    selectoptions,
   };
   return (
     <Slot

--- a/src/ModelForm/ModelFormField.tsx
+++ b/src/ModelForm/ModelFormField.tsx
@@ -61,7 +61,7 @@ export const ModelFormField = ({
                 <Lens lens={DataLens.INPUT}>
                   <FormControl
                     name={field}
-                    options={valueOptions}
+                    selectoptions={valueOptions}
                     rules={{
                       required: required && `${label} is required.`,
                       ...rules,

--- a/src/ModelTable/ModelTableCell.tsx
+++ b/src/ModelTable/ModelTableCell.tsx
@@ -87,7 +87,7 @@ export const ModelTableCell = ({
               <Lens lens={DataLens.INPUT}>
                 <FormControl
                   name={field}
-                  options={valueOptions}
+                  selectoptions={valueOptions}
                   rules={{
                     required: required && `${label} is required.`,
                     ...rules,

--- a/src/utils/components/ScrollAreaWrapper.tsx
+++ b/src/utils/components/ScrollAreaWrapper.tsx
@@ -20,7 +20,7 @@ export const ScrollAreaWrapper = ({
   children,
 }: ScrollAreaWrapperProps) => {
   const ref = useRef<ElementRef<typeof ScrollArea> | null>(null);
-  
+
   const lastElementChild = ref.current?.lastElementChild;
   const scrollWidth = lastElementChild?.scrollWidth;
   const clientWidth = lastElementChild?.clientWidth;
@@ -30,15 +30,9 @@ export const ScrollAreaWrapper = ({
     if (!lastElementChild || !scrollWidth || !clientWidth) return;
 
     const observer = new ResizeObserver(() => {
-      if (
-        scrollWidth > clientWidth &&
-        !isOverflow 
-      ) {
-        setIsOverflow(true); 
-      } else if (
-        scrollWidth <= clientWidth &&
-        isOverflow
-      ) {
+      if (scrollWidth > clientWidth && !isOverflow) {
+        setIsOverflow(true);
+      } else if (scrollWidth <= clientWidth && isOverflow) {
         setIsOverflow(false);
       }
     });


### PR DESCRIPTION
- `bugfix`: `SelectInput`'s options now allow any DataType for its options to utilize the `getOptionLabel` and `getOptionValue` props. The options passed into `fieldOptions` for `ModelTable/ModelForm` can be accessed from the form control by `selectoptions`. 