### PR TITLE
Feature: Per page dropdown direction customization

### DIFF
--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -35,12 +35,13 @@ export const SelectInput = forwardRef<
         'flex-nowrap',
         'items-center',
       ),
-    dropdownIndicator: ({ isFocused }) =>
+    dropdownIndicator: ({ isFocused, selectProps }) =>
       cn(
         'p-2',
         isFocused
           ? 'text-muted-foreground hover:text-foreground'
           : 'text-foreground hover:text-muted-foreground',
+        selectProps.menuPlacement === 'top' ? 'rotate-180' : ''
       ),
     group: () => cn('py-2'),
     groupHeading: () =>

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -41,7 +41,7 @@ export const SelectInput = forwardRef<
         isFocused
           ? 'text-muted-foreground hover:text-foreground'
           : 'text-foreground hover:text-muted-foreground',
-        selectProps.menuPlacement === 'top' ? 'rotate-180' : ''
+        selectProps.menuPlacement === 'top' ? 'rotate-180' : '',
       ),
     group: () => cn('py-2'),
     groupHeading: () =>

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -15,6 +15,7 @@ export interface PaginationProps
   onPageChange: (newPage: TableView['page']) => void;
   onPerPageChange?: (newPerPage: TableView['perPage']) => void;
   perPageOptions?: typeof PER_PAGE_VALUES;
+  openPerPageUpwards?: boolean;
 }
 
 const PER_PAGE_VALUES = [
@@ -33,6 +34,7 @@ export const Pagination = ({
   onPageChange,
   onPerPageChange,
   perPageOptions = PER_PAGE_VALUES,
+  openPerPageUpwards,
   className,
   ...paginationProps
 }: PaginationProps) => {
@@ -126,6 +128,7 @@ export const Pagination = ({
                 onPerPageChange(selected.value);
               }}
               className="mr-2"
+              menuPlacement={openPerPageUpwards ? 'top' : 'bottom'}
             />
           </>
         )}


### PR DESCRIPTION
- Adds the ability for the user to choose, through a prop, which direction they'd like the dropdown to open in, and switches the arrow depending on the direction they chose
- Elected to go this route since using `menuPlacement: auto` in _react-select_ doesn't change the direction of the arrow is displayed. It also doesn't include the direction the menu would be displayed in, if it were opened, as a prop to be used in it's styling
