### PR TITLE
Bugfix: Remove Datetime fixed widths

### DIFF
--- a/src/BasicInputs/stories/DatetimeInput.stories.tsx
+++ b/src/BasicInputs/stories/DatetimeInput.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     const [date, setDate] = useState<string | undefined | null>(
       '2024-07-10T23:12:34',
     );
-    return <DatetimeInput value={date} onChange={setDate} hourCycle={24} />;
+    return <DatetimeInput value={date} onChange={setDate} hourCycle={12} />;
   },
 } satisfies Meta<typeof DatetimeInput>;
 export default meta;

--- a/src/lib/components/ui/time-period-select.tsx
+++ b/src/lib/components/ui/time-period-select.tsx
@@ -65,7 +65,7 @@ export const TimePeriodSelect = React.forwardRef<
       >
         <SelectTrigger
           ref={ref}
-          className='h-10 w-16 focus:bg-accent focus:text-accent-foreground'
+          className="h-10 w-16 focus:bg-accent focus:text-accent-foreground"
           onKeyDown={handleKeyDown}
         >
           <SelectValue />

--- a/src/lib/components/ui/time-period-select.tsx
+++ b/src/lib/components/ui/time-period-select.tsx
@@ -65,7 +65,7 @@ export const TimePeriodSelect = React.forwardRef<
       >
         <SelectTrigger
           ref={ref}
-          className="h-[42px] w-[65px] focus:bg-accent focus:text-accent-foreground"
+          className='h-10 w-16 focus:bg-accent focus:text-accent-foreground'
           onKeyDown={handleKeyDown}
         >
           <SelectValue />

--- a/src/lib/components/ui/time-picker-input.tsx
+++ b/src/lib/components/ui/time-picker-input.tsx
@@ -109,7 +109,7 @@ const TimePickerInput = React.forwardRef<
         id={id || picker}
         name={name || picker}
         className={cn(
-          'w-[48px] text-center font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none',
+          'h-10 w-12 text-center font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none',
           className,
         )}
         value={value || calculatedValue}


### PR DESCRIPTION
* Text is no longer cut off when html font-size is changed
* Hours/Minutes/Seconds/Period inputs now use rem instead of pixels for width/height
* The inputs now all have the same height
