### PR TITLE
Bugfix: Removed Scrollbar Z-Index

### DIFF
--- a/src/lib/components/ui/scroll-area.tsx
+++ b/src/lib/components/ui/scroll-area.tsx
@@ -36,7 +36,7 @@ const ScrollBar = React.forwardRef<
       orientation === 'vertical' &&
         'h-full w-2.5 border-l border-l-transparent p-[1px]',
       orientation === 'horizontal' &&
-        'z-20 h-2.5 flex-col border-t border-t-transparent p-[1px]',
+        'h-2.5 flex-col border-t border-t-transparent p-[1px]',
       className,
     )}
     {...props}


### PR DESCRIPTION
### Changes
* removed z-index for the horizontal scroll bar

When `menuPortalTarget` for `Select` is set to `document.body`, the scrollbar used to render above the options (not good). Increasing the z-index of the menu and/or menu options did not solve this problem, but removing the z-index for the scrollbar did. Also, the z-index was only present on the horizontal scroll bar and not the vertical one for some reason.