### PR TITLE
Bugfix: Enum Select Inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lucide-react": "^0.408.0",
     "react-day-picker": "9.3.0",
     "react-hook-form": "^7.53.2",
-    "react-select": "^5.8.3",
+    "react-select": "^5.9.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^4.5.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^7.53.2
         version: 7.53.2(react@18.3.1)
       react-select:
-        specifier: ^5.8.3
-        version: 5.8.3(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^5.9.0
+        version: 5.9.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -3229,11 +3229,11 @@ packages:
       '@types/react':
         optional: true
 
-  react-select@5.8.3:
-    resolution: {integrity: sha512-lVswnIq8/iTj1db7XCG74M/3fbGB6ZaluCzvwPGT5ZOjCdL/k0CLWhEK0vCBLuU5bHTEf6Gj8jtSvi+3v+tO1w==}
+  react-select@5.9.0:
+    resolution: {integrity: sha512-nwRKGanVHGjdccsnzhFte/PULziueZxGD8LL2WojON78Mvnq7LdAMEtu2frrwld1fr3geixg3iiMBIc/LLAZpw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
@@ -3622,11 +3622,11 @@ packages:
       '@types/react':
         optional: true
 
-  use-isomorphic-layout-effect@1.1.2:
-    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+  use-isomorphic-layout-effect@1.2.0:
+    resolution: {integrity: sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6934,7 +6934,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  react-select@5.8.3(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-select@5.9.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.7
       '@emotion/cache': 11.13.1
@@ -6946,7 +6946,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.3.11)(react@18.3.1)
+      use-isomorphic-layout-effect: 1.2.0(@types/react@18.3.11)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -7367,7 +7367,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  use-isomorphic-layout-effect@1.1.2(@types/react@18.3.11)(react@18.3.1):
+  use-isomorphic-layout-effect@1.2.0(@types/react@18.3.11)(react@18.3.1):
     dependencies:
       react: 18.3.1
     optionalDependencies:

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -30,12 +30,12 @@ export const EnumInput = forwardRef<
       }
       options={options?.map(stringToOption)}
       onChange={(newValue, actionMeta) =>
-        Array.isArray(newValue)
-          ? onChange?.(
-              newValue.map((val) => val.value),
-              actionMeta,
-            )
-          : onChange?.(newValue?.value, actionMeta)
+        onChange?.(
+          Array.isArray(newValue)
+            ? newValue.map((val) => val.value)
+            : newValue?.value,
+          actionMeta,
+        )
       }
       {...selectInputProps}
     />

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -33,7 +33,7 @@ export const EnumInput = forwardRef<
         onChange?.(
           Array.isArray(newValue)
             ? newValue.map((val) => val.value)
-            : newValue?.value,
+            : newValue?.value ?? null,
           actionMeta,
         )
       }

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -37,7 +37,6 @@ export const EnumInput = forwardRef<
       options={options?.map(stringToOption)}
       isMulti={isArray}
       clearValue={isArray ? () => [] : undefined}
-      isClearable={isArray}
       isCreatable={isCreatable}
       {...selectInputProps}
     />

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -30,7 +30,10 @@ export const EnumInput = forwardRef<
       }
       onChange={(newValue, actionMeta) =>
         Array.isArray(newValue)
-          ? onChange?.(newValue.map((val) => val.value), actionMeta)
+          ? onChange?.(
+              newValue.map((val) => val.value),
+              actionMeta,
+            )
           : onChange?.(newValue?.value, actionMeta)
       }
       options={options?.map(stringToOption)}

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -7,12 +7,14 @@ import {
 import { humanizeText } from '@/utils';
 
 import { SelectInput } from './SelectInput';
+import type { SelectOption } from '@/types';
 
 export const EnumInput = forwardRef<
   ElementRef<typeof SelectInput>,
   Omit<ComponentPropsWithoutRef<typeof SelectInput>, 'value' | 'options'> & {
-    value: string;
+    value?: string | string[];
     options: string[];
+    onChange: (newVals : string | string[]) => void
   }
 >(({ value, onChange, options, isCreatable, ...selectInputProps }, ref) => {
   const isArray = Array.isArray(value);
@@ -26,21 +28,18 @@ export const EnumInput = forwardRef<
       value={
         value && (isArray ? value.map(stringToOption) : stringToOption(value))
       }
-      onChange={(newVal, actionMeta) => onChange?.(newVal.value, actionMeta)}
+      onChange={(newValue : SelectOption | SelectOption[]) => 
+        newValue && (
+          Array.isArray(newValue) ?
+          onChange?.(newValue.map( val => val.value)) :
+          onChange?.(newValue.value)
+        )
+      }
       options={options?.map(stringToOption)}
       isMulti={isArray}
       clearValue={isArray ? () => [] : undefined}
-      isClearable={!isArray}
-      closeMenuOnSelect={!isArray}
+      isClearable={isArray}
       isCreatable={isCreatable}
-      getNewOptionData={
-        isCreatable
-          ? (inputValue, optionLabel) => ({
-              displayValue: optionLabel,
-              id: inputValue,
-            })
-          : undefined
-      }
       {...selectInputProps}
     />
   );

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -16,8 +16,7 @@ export const EnumInput = forwardRef<
     options: string[];
     onChange: (newVals: string | string[]) => void;
   }
->(({ value, onChange, options, isCreatable, ...selectInputProps }, ref) => {
-  const isArray = Array.isArray(value);
+>(({ value, onChange, options, ...selectInputProps }, ref) => {
   const stringToOption = (str: string) => ({
     label: humanizeText(str),
     value: str,
@@ -26,18 +25,14 @@ export const EnumInput = forwardRef<
     <SelectInput
       ref={ref}
       value={
-        value && (isArray ? value.map(stringToOption) : stringToOption(value))
+        value && (Array.isArray(value) ? value.map(stringToOption) : stringToOption(value))
       }
-      onChange={(newValue: SelectOption | SelectOption[]) =>
-        newValue &&
-        (Array.isArray(newValue)
+      onChange={(newValue: SelectOption | SelectOption[] | null) => 
+        Array.isArray(newValue)
           ? onChange?.(newValue.map((val) => val.value))
-          : onChange?.(newValue.value))
+          : onChange?.(newValue?.value)
       }
       options={options?.map(stringToOption)}
-      isMulti={isArray}
-      clearValue={isArray ? () => [] : undefined}
-      isCreatable={isCreatable}
       {...selectInputProps}
     />
   );

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -28,6 +28,7 @@ export const EnumInput = forwardRef<
           ? value.map(stringToOption)
           : stringToOption(value))
       }
+      options={options?.map(stringToOption)}
       onChange={(newValue, actionMeta) =>
         Array.isArray(newValue)
           ? onChange?.(
@@ -36,7 +37,6 @@ export const EnumInput = forwardRef<
             )
           : onChange?.(newValue?.value, actionMeta)
       }
-      options={options?.map(stringToOption)}
       {...selectInputProps}
     />
   );

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -4,17 +4,17 @@ import {
   forwardRef,
 } from 'react';
 
+import type { SelectOption } from '@/types';
 import { humanizeText } from '@/utils';
 
 import { SelectInput } from './SelectInput';
-import type { SelectOption } from '@/types';
 
 export const EnumInput = forwardRef<
   ElementRef<typeof SelectInput>,
   Omit<ComponentPropsWithoutRef<typeof SelectInput>, 'value' | 'options'> & {
     value?: string | string[];
     options: string[];
-    onChange: (newVals : string | string[]) => void
+    onChange: (newVals: string | string[]) => void;
   }
 >(({ value, onChange, options, isCreatable, ...selectInputProps }, ref) => {
   const isArray = Array.isArray(value);
@@ -28,12 +28,11 @@ export const EnumInput = forwardRef<
       value={
         value && (isArray ? value.map(stringToOption) : stringToOption(value))
       }
-      onChange={(newValue : SelectOption | SelectOption[]) => 
-        newValue && (
-          Array.isArray(newValue) ?
-          onChange?.(newValue.map( val => val.value)) :
-          onChange?.(newValue.value)
-        )
+      onChange={(newValue: SelectOption | SelectOption[]) =>
+        newValue &&
+        (Array.isArray(newValue)
+          ? onChange?.(newValue.map((val) => val.value))
+          : onChange?.(newValue.value))
       }
       options={options?.map(stringToOption)}
       isMulti={isArray}

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -25,9 +25,12 @@ export const EnumInput = forwardRef<
     <SelectInput
       ref={ref}
       value={
-        value && (Array.isArray(value) ? value.map(stringToOption) : stringToOption(value))
+        value &&
+        (Array.isArray(value)
+          ? value.map(stringToOption)
+          : stringToOption(value))
       }
-      onChange={(newValue: SelectOption | SelectOption[] | null) => 
+      onChange={(newValue: SelectOption | SelectOption[] | null) =>
         Array.isArray(newValue)
           ? onChange?.(newValue.map((val) => val.value))
           : onChange?.(newValue?.value)

--- a/src/BasicInputs/EnumInput.tsx
+++ b/src/BasicInputs/EnumInput.tsx
@@ -4,7 +4,6 @@ import {
   forwardRef,
 } from 'react';
 
-import type { SelectOption } from '@/types';
 import { humanizeText } from '@/utils';
 
 import { SelectInput } from './SelectInput';
@@ -14,7 +13,6 @@ export const EnumInput = forwardRef<
   Omit<ComponentPropsWithoutRef<typeof SelectInput>, 'value' | 'options'> & {
     value?: string | string[];
     options: string[];
-    onChange: (newVals: string | string[]) => void;
   }
 >(({ value, onChange, options, ...selectInputProps }, ref) => {
   const stringToOption = (str: string) => ({
@@ -30,10 +28,10 @@ export const EnumInput = forwardRef<
           ? value.map(stringToOption)
           : stringToOption(value))
       }
-      onChange={(newValue: SelectOption | SelectOption[] | null) =>
+      onChange={(newValue, actionMeta) =>
         Array.isArray(newValue)
-          ? onChange?.(newValue.map((val) => val.value))
-          : onChange?.(newValue?.value)
+          ? onChange?.(newValue.map((val) => val.value), actionMeta)
+          : onChange?.(newValue?.value, actionMeta)
       }
       options={options?.map(stringToOption)}
       {...selectInputProps}

--- a/src/BasicInputs/ModelInput.tsx
+++ b/src/BasicInputs/ModelInput.tsx
@@ -9,29 +9,17 @@ import { SelectInput } from './SelectInput';
 export const ModelInput = forwardRef<
   ElementRef<typeof SelectInput>,
   ComponentPropsWithoutRef<typeof SelectInput>
->(({ value, onChange, options, isCreatable, ...selectInputProps }, ref) => {
-  const isArray = Array.isArray(value);
+>(({ value,  ...selectInputProps }, ref) => {
   return (
     <SelectInput
       ref={ref}
       value={value}
-      onChange={onChange}
       getOptionLabel={(option: typeof value) => option.displayValue}
       getOptionValue={(option: typeof value) => option.id}
-      options={options}
-      isMulti={isArray}
-      clearValue={isArray ? () => [] : undefined}
-      isClearable={!isArray}
-      closeMenuOnSelect={!isArray}
-      isCreatable={true}
-      getNewOptionData={
-        isCreatable
-          ? (inputValue, optionLabel) => ({
-              displayValue: optionLabel,
-              id: inputValue,
-            })
-          : undefined
-      }
+      getNewOptionData={(inputValue, optionLabel) => ({
+        displayValue: optionLabel,
+        id: inputValue,
+      })}
       {...selectInputProps}
     />
   );

--- a/src/BasicInputs/ModelInput.tsx
+++ b/src/BasicInputs/ModelInput.tsx
@@ -9,7 +9,7 @@ import { SelectInput } from './SelectInput';
 export const ModelInput = forwardRef<
   ElementRef<typeof SelectInput>,
   ComponentPropsWithoutRef<typeof SelectInput>
->(({ value,  ...selectInputProps }, ref) => {
+>(({ value, ...selectInputProps }, ref) => {
   return (
     <SelectInput
       ref={ref}

--- a/src/BasicInputs/ModelInput.tsx
+++ b/src/BasicInputs/ModelInput.tsx
@@ -1,4 +1,8 @@
-import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react';
+import {
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  forwardRef,
+} from 'react';
 
 import { SelectInput } from './SelectInput';
 

--- a/src/BasicInputs/ModelInput.tsx
+++ b/src/BasicInputs/ModelInput.tsx
@@ -9,13 +9,12 @@ import { SelectInput } from './SelectInput';
 export const ModelInput = forwardRef<
   ElementRef<typeof SelectInput>,
   ComponentPropsWithoutRef<typeof SelectInput>
->(({ value, ...selectInputProps }, ref) => {
+>(({ ...selectInputProps }, ref) => {
   return (
     <SelectInput
       ref={ref}
-      value={value}
-      getOptionLabel={(option: typeof value) => option.displayValue}
-      getOptionValue={(option: typeof value) => option.id}
+      getOptionLabel={(option) => option.displayValue}
+      getOptionValue={(option) => option.id}
       getNewOptionData={(inputValue, optionLabel) => ({
         displayValue: optionLabel,
         id: inputValue,

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -143,7 +143,6 @@ export const SelectInput = forwardRef<
     isMulti: isArray,
     closeMenuOnSelect: !isArray,
     isClearable: true,
-    clearValue: () => (isArray ? [] : 'das'),
     menuShouldBlockScroll: true,
   };
 

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -133,7 +133,6 @@ export const SelectInput = forwardRef<
       {isCreatable ? (
         <Creatable
           ref={ref}
-          options={options}
           unstyled
           classNames={defaultStyling}
           isDisabled={disabled}
@@ -148,7 +147,6 @@ export const SelectInput = forwardRef<
       ) : (
         <Select
           ref={ref}
-          options={options}
           unstyled
           classNames={defaultStyling}
           isDisabled={disabled}

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -42,7 +42,7 @@ export type SelectInputProps<TIsCreatable extends boolean> =
 export const SelectInput = forwardRef<
   ElementRef<typeof Select>,
   SelectInputProps<boolean>
->(({ id, disabled, className, isMulti, isCreatable, ...props }, ref) => {
+>(({ id, disabled, className, isCreatable, ...props }, ref) => {
   const defaultStyling: ComponentProps<typeof Select>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -147,6 +147,8 @@ export const SelectInput = forwardRef<
           inputId={id}
           menuPlacement="auto"
           menuPortalTarget={document.body}
+          closeMenuOnSelect={!props.isMulti}
+          isClearable
           menuShouldBlockScroll
           {...props}
         />
@@ -160,6 +162,8 @@ export const SelectInput = forwardRef<
           inputId={id}
           menuPlacement="auto"
           menuPortalTarget={document.body}
+          closeMenuOnSelect={!props.isMulti}
+          isClearable
           menuShouldBlockScroll
           {...props}
         />

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -42,7 +42,7 @@ export type SelectInputProps<TIsCreatable extends boolean> =
 export const SelectInput = forwardRef<
   ElementRef<typeof Select>,
   SelectInputProps<boolean>
->(({ id, disabled, className, isCreatable, ...props }, ref) => {
+>(({ id, disabled, className, isMulti, isCreatable, ...props }, ref) => {
   const defaultStyling: ComponentProps<typeof Select>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
@@ -122,6 +122,8 @@ export const SelectInput = forwardRef<
       cn('py-0.5', 'px-3', 'overflow-visible', 'inline-block'),
   };
 
+  const isArray = Array.isArray(props.value);
+
   return (
     <div
       className={cn(
@@ -139,7 +141,8 @@ export const SelectInput = forwardRef<
           inputId={id}
           menuPlacement="auto"
           menuPortalTarget={document.body}
-          closeMenuOnSelect={!props.isMulti}
+          isMulti={isArray}
+          closeMenuOnSelect={!isArray}
           isClearable
           menuShouldBlockScroll
           {...props}
@@ -153,7 +156,8 @@ export const SelectInput = forwardRef<
           inputId={id}
           menuPlacement="auto"
           menuPortalTarget={document.body}
-          closeMenuOnSelect={!props.isMulti}
+          isMulti={isArray}
+          closeMenuOnSelect={!isArray}
           isClearable
           menuShouldBlockScroll
           {...props}

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -42,7 +42,7 @@ export type SelectInputProps<TIsCreatable extends boolean> =
 export const SelectInput = forwardRef<
   ElementRef<typeof Select>,
   SelectInputProps<boolean>
->(({ id, disabled, className, options, isCreatable, ...props }, ref) => {
+>(({ id, disabled, className, isCreatable, ...props }, ref) => {
   const defaultStyling: ComponentProps<typeof Select>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
@@ -143,7 +143,6 @@ export const SelectInput = forwardRef<
           unstyled
           classNames={defaultStyling}
           isDisabled={disabled}
-          options={options}
           inputId={id}
           menuPlacement="auto"
           menuPortalTarget={document.body}
@@ -158,7 +157,6 @@ export const SelectInput = forwardRef<
           unstyled
           classNames={defaultStyling}
           isDisabled={disabled}
-          options={options}
           inputId={id}
           menuPlacement="auto"
           menuPortalTarget={document.body}

--- a/src/BasicInputs/SelectInput.tsx
+++ b/src/BasicInputs/SelectInput.tsx
@@ -42,7 +42,7 @@ export type SelectInputProps<TIsCreatable extends boolean> =
 export const SelectInput = forwardRef<
   ElementRef<typeof Select>,
   SelectInputProps<boolean>
->(({ id, disabled, className, isCreatable, ...props }, ref) => {
+>(({ id, disabled, className, isCreatable, isMulti, ...props }, ref) => {
   const defaultStyling: ComponentProps<typeof Select>['classNames'] = {
     clearIndicator: ({ isFocused }) =>
       cn(
@@ -122,7 +122,21 @@ export const SelectInput = forwardRef<
       cn('py-0.5', 'px-3', 'overflow-visible', 'inline-block'),
   };
 
-  const isArray = Array.isArray(props.value);
+  const isArray = Array.isArray(props.value) || isMulti;
+  const commonProps: ComponentProps<typeof Select> = {
+    ref,
+    unstyled: true,
+    classNames: defaultStyling,
+    isDisabled: disabled,
+    inputId: id,
+    menuPlacement: 'auto',
+    menuPortalTarget: document.body,
+    isMulti: isArray,
+    closeMenuOnSelect: !isArray,
+    isClearable: true,
+    clearValue: () => (isArray ? [] : 'das'),
+    menuShouldBlockScroll: true,
+  };
 
   return (
     <div
@@ -133,35 +147,9 @@ export const SelectInput = forwardRef<
       )}
     >
       {isCreatable ? (
-        <Creatable
-          ref={ref}
-          unstyled
-          classNames={defaultStyling}
-          isDisabled={disabled}
-          inputId={id}
-          menuPlacement="auto"
-          menuPortalTarget={document.body}
-          isMulti={isArray}
-          closeMenuOnSelect={!isArray}
-          isClearable
-          menuShouldBlockScroll
-          {...props}
-        />
+        <Creatable {...commonProps} {...props} />
       ) : (
-        <Select
-          ref={ref}
-          unstyled
-          classNames={defaultStyling}
-          isDisabled={disabled}
-          inputId={id}
-          menuPlacement="auto"
-          menuPortalTarget={document.body}
-          isMulti={isArray}
-          closeMenuOnSelect={!isArray}
-          isClearable
-          menuShouldBlockScroll
-          {...props}
-        />
+        <Select {...commonProps} {...props} />
       )}
     </div>
   );

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -1,59 +1,37 @@
-import { useState } from 'react';
-
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EnumInput } from '../EnumInput';
+import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/EnumInput',
   tags: ['autodocs'],
+  args: {
+    options: ['apple', 'banana', 'orange', 'kiwi', 'lemon'],
+  },
+  component: EnumInput,
 } satisfies Meta<typeof EnumInput>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Select: Story = {
-  render: () => {
-    const [value, setValue] = useState<string>();
-    const options = ['apple', 'banana', 'orange', 'kiwi', 'lemon'];
-
-    return (
-      <EnumInput
-        options={options}
-        value={value}
-        onChange={(newVals) => setValue(newVals)}
-      />
-    );
-  },
-};
+export const Select: Story = {};
 
 export const CreatableSelect: Story = {
-  render: () => {
-    const [value, setValue] = useState<string>();
-    const options = ['apple', 'banana', 'orange', 'kiwi', 'lemon'];
-
-    return (
-      <EnumInput
-        isCreatable
-        options={options}
-        value={value}
-        onChange={(newVals) => setValue(newVals)}
-      />
-    );
+  args: {
+    isCreatable: true,
   },
 };
 
 export const MultiSelect: Story = {
-  render: () => {
-    const [values, setValues] = useState<string[]>([]);
-    const options = ['apple', 'banana', 'orange', 'kiwi', 'lemon'];
+  args: {
+    isMulti: true,
+  },
+};
 
-    return (
-      <EnumInput
-        options={options}
-        value={values}
-        onChange={(newVals) => setValues(newVals)}
-      />
-    );
+export const MultiSelectWithValueInference: Story = {
+  render: (args) => {
+    const [values, setValues] = useState<string[]>([]);
+    return <EnumInput {...args} value={values} onChange={setValues} />;
   },
 };

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -1,25 +1,59 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EnumInput } from '../EnumInput';
+import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/EnumInput',
-  component: EnumInput,
   tags: ['autodocs'],
-  args: {
-    options: ['apple', 'banana', 'orange', 'kiwi', 'lemon'],
-    onChange: (newVal) => console.log(newVal),
-    value: 'kiwi',
-  },
 } satisfies Meta<typeof EnumInput>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Select: Story = {};
+export const Select: Story = {
+  render: () => {
+    const [value, setValue] = useState<string>();
+    const options = ['apple', 'banana', 'orange', 'kiwi', 'lemon'];
+
+    return (
+      <EnumInput
+        options={options}
+        value={value}
+        onChange={(newVals) => setValue(newVals)}
+      />
+    )
+  }
+};
 
 export const CreatableSelect: Story = {
-  args: {
-    isCreatable: true,
-  },
+  render: () => {
+    const [value, setValue] = useState<string>();
+    const options = ['apple', 'banana', 'orange', 'kiwi', 'lemon'];
+
+    return (
+      <EnumInput
+        isCreatable
+        options={options}
+        value={value}
+        onChange={(newVals) => setValue(newVals)}
+      />
+    )
+  }
 };
+
+export const MultiSelect: Story = {
+  render: () => {
+    const [values, setValues] = useState<string[]>([]);
+    const options = ['apple', 'banana', 'orange', 'kiwi', 'lemon'];
+
+    return (
+      <EnumInput
+        isCreatable
+        options={options}
+        value={values}
+        onChange={(newVals) => setValues(newVals)}
+      />
+    )
+  }
+}

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -50,7 +50,6 @@ export const MultiSelect: Story = {
 
     return (
       <EnumInput
-        isCreatable
         options={options}
         value={values}
         onChange={(newVals) => setValues(newVals)}

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -12,7 +12,6 @@ const meta = {
   },
   render: (props) => {
     const [values, setValues] = useState<any>(props.value);
-    console.log(values);
     return (
       <div className="space-y-2">
         <div>Value: {JSON.stringify(values)}</div>

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -5,11 +5,20 @@ import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/EnumInput',
+  component: EnumInput,
   tags: ['autodocs'],
   args: {
     options: ['apple', 'banana', 'orange', 'kiwi', 'lemon'],
   },
-  component: EnumInput,
+  render: (props) => {
+    const [values, setValues] = useState<any>(props.value);
+    return (
+      <div className="space-y-2">
+        <div>Value: {JSON.stringify(values)}</div>
+        <EnumInput {...props} value={values} onChange={setValues} />
+      </div>
+    );
+  },
 } satisfies Meta<typeof EnumInput>;
 export default meta;
 
@@ -29,9 +38,16 @@ export const MultiSelect: Story = {
   },
 };
 
+export const CreatableMultiSelect: Story = {
+  args: {
+    isMulti: true,
+    isCreatable: true,
+  },
+};
+
 export const MultiSelectWithValueInference: Story = {
-  render: (args) => {
+  render: (props) => {
     const [values, setValues] = useState<string[]>([]);
-    return <EnumInput {...args} value={values} onChange={setValues} />;
+    return <EnumInput {...props} value={values} onChange={setValues} />;
   },
 };

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -51,6 +51,7 @@ export const MultiSelect: Story = {
     return (
       <EnumInput
         isCreatable
+        isMulti
         options={options}
         value={values}
         onChange={(newVals) => setValues(newVals)}

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -12,6 +12,7 @@ const meta = {
   },
   render: (props) => {
     const [values, setValues] = useState<any>(props.value);
+    console.log(values);
     return (
       <div className="space-y-2">
         <div>Value: {JSON.stringify(values)}</div>
@@ -46,8 +47,7 @@ export const CreatableMultiSelect: Story = {
 };
 
 export const MultiSelectWithValueInference: Story = {
-  render: (props) => {
-    const [values, setValues] = useState<string[]>([]);
-    return <EnumInput {...props} value={values} onChange={setValues} />;
+  args: {
+    value: [],
   },
 };

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -51,7 +51,6 @@ export const MultiSelect: Story = {
     return (
       <EnumInput
         isCreatable
-        isMulti
         options={options}
         value={values}
         onChange={(newVals) => setValues(newVals)}

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EnumInput } from '../EnumInput';
-import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/EnumInput',
@@ -22,8 +23,8 @@ export const Select: Story = {
         value={value}
         onChange={(newVals) => setValue(newVals)}
       />
-    )
-  }
+    );
+  },
 };
 
 export const CreatableSelect: Story = {
@@ -38,8 +39,8 @@ export const CreatableSelect: Story = {
         value={value}
         onChange={(newVals) => setValue(newVals)}
       />
-    )
-  }
+    );
+  },
 };
 
 export const MultiSelect: Story = {
@@ -54,6 +55,6 @@ export const MultiSelect: Story = {
         value={values}
         onChange={(newVals) => setValues(newVals)}
       />
-    )
-  }
-}
+    );
+  },
+};

--- a/src/BasicInputs/stories/EnumInput.stories.tsx
+++ b/src/BasicInputs/stories/EnumInput.stories.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EnumInput } from '../EnumInput';
-import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/EnumInput',

--- a/src/BasicInputs/stories/ModelInput.stories.tsx
+++ b/src/BasicInputs/stories/ModelInput.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ModelInput } from '../ModelInput';
+
+const meta = {
+  title: 'Commons/BasicInputs/ModelInput',
+  tags: ['autodocs'],
+  args: {
+    options: [
+      { id: 'apple', displayValue: 'Apple' },
+      { id: 'mountain', displayValue: 'Mountain' },
+      { id: 'ocean', displayValue: 'Ocean' },
+      { id: 'whisper', displayValue: 'Whisper' },
+      { id: 'butterfly', displayValue: 'Butterfly' },
+      { id: 'galaxy', displayValue: 'Galaxy' },
+      { id: 'harmony', displayValue: 'Harmony' },
+      { id: 'puzzle', displayValue: 'Puzzle' },
+      { id: 'symphony', displayValue: 'Symphony' },
+      { id: 'labyrinth', displayValue: 'Labyrinth' },
+    ],
+  },
+  component: ModelInput
+} satisfies Meta<typeof ModelInput>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Select : Story = {}
+
+export const Creatable : Story = {
+  args: {
+    isCreatable: true,
+  }
+} 
+
+export const Multi : Story = {
+  args: {
+    isMulti: true
+  }
+}

--- a/src/BasicInputs/stories/ModelInput.stories.tsx
+++ b/src/BasicInputs/stories/ModelInput.stories.tsx
@@ -22,6 +22,15 @@ const meta = {
       { id: 'labyrinth', displayValue: 'Labyrinth' },
     ],
   },
+  render: (props) => {
+    const [values, setValues] = useState<any>(props.value);
+    return (
+      <div className="space-y-2">
+        <div>Value: {JSON.stringify(values)}</div>
+        <ModelInput {...props} value={values} onChange={setValues} />
+      </div>
+    );
+  },
 } satisfies Meta<typeof ModelInput>;
 export default meta;
 
@@ -29,32 +38,27 @@ type Story = StoryObj<typeof meta>;
 
 export const Select: Story = {};
 
-export const Creatable: Story = {
+export const CreatableSelect: Story = {
   args: {
     isCreatable: true,
   },
 };
 
-export const Multi: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    return (
-      <ModelInput
-        value={value}
-        onChange={setValue}
-        options={[
-          { id: 'apple', displayValue: 'Apple' },
-          { id: 'mountain', displayValue: 'Mountain' },
-          { id: 'ocean', displayValue: 'Ocean' },
-          { id: 'whisper', displayValue: 'Whisper' },
-          { id: 'butterfly', displayValue: 'Butterfly' },
-          { id: 'galaxy', displayValue: 'Galaxy' },
-          { id: 'harmony', displayValue: 'Harmony' },
-          { id: 'puzzle', displayValue: 'Puzzle' },
-          { id: 'symphony', displayValue: 'Symphony' },
-          { id: 'labyrinth', displayValue: 'Labyrinth' },
-        ]}
-      />
-    );
+export const MultiSelect: Story = {
+  args: {
+    isMulti: true,
+  },
+};
+
+export const CreatableMultiSelect: Story = {
+  args: {
+    isMulti: true,
+    isCreatable: true,
+  },
+};
+
+export const MultiSelectWithValueInference: Story = {
+  args: {
+    value: [],
   },
 };

--- a/src/BasicInputs/stories/ModelInput.stories.tsx
+++ b/src/BasicInputs/stories/ModelInput.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ModelInput } from '../ModelInput';
+import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/ModelInput',
@@ -34,7 +35,23 @@ export const Creatable: Story = {
 };
 
 export const Multi: Story = {
-  args: {
-    isMulti: true,
-  },
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return <ModelInput
+      value={value}
+      onChange={setValue}
+      options={[
+        { id: 'apple', displayValue: 'Apple' },
+        { id: 'mountain', displayValue: 'Mountain' },
+        { id: 'ocean', displayValue: 'Ocean' },
+        { id: 'whisper', displayValue: 'Whisper' },
+        { id: 'butterfly', displayValue: 'Butterfly' },
+        { id: 'galaxy', displayValue: 'Galaxy' },
+        { id: 'harmony', displayValue: 'Harmony' },
+        { id: 'puzzle', displayValue: 'Puzzle' },
+        { id: 'symphony', displayValue: 'Symphony' },
+        { id: 'labyrinth', displayValue: 'Labyrinth' },
+      ]}
+    />
+  }
 };

--- a/src/BasicInputs/stories/ModelInput.stories.tsx
+++ b/src/BasicInputs/stories/ModelInput.stories.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ModelInput } from '../ModelInput';
-import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/ModelInput',
@@ -37,21 +38,23 @@ export const Creatable: Story = {
 export const Multi: Story = {
   render: () => {
     const [value, setValue] = useState<string[]>([]);
-    return <ModelInput
-      value={value}
-      onChange={setValue}
-      options={[
-        { id: 'apple', displayValue: 'Apple' },
-        { id: 'mountain', displayValue: 'Mountain' },
-        { id: 'ocean', displayValue: 'Ocean' },
-        { id: 'whisper', displayValue: 'Whisper' },
-        { id: 'butterfly', displayValue: 'Butterfly' },
-        { id: 'galaxy', displayValue: 'Galaxy' },
-        { id: 'harmony', displayValue: 'Harmony' },
-        { id: 'puzzle', displayValue: 'Puzzle' },
-        { id: 'symphony', displayValue: 'Symphony' },
-        { id: 'labyrinth', displayValue: 'Labyrinth' },
-      ]}
-    />
-  }
+    return (
+      <ModelInput
+        value={value}
+        onChange={setValue}
+        options={[
+          { id: 'apple', displayValue: 'Apple' },
+          { id: 'mountain', displayValue: 'Mountain' },
+          { id: 'ocean', displayValue: 'Ocean' },
+          { id: 'whisper', displayValue: 'Whisper' },
+          { id: 'butterfly', displayValue: 'Butterfly' },
+          { id: 'galaxy', displayValue: 'Galaxy' },
+          { id: 'harmony', displayValue: 'Harmony' },
+          { id: 'puzzle', displayValue: 'Puzzle' },
+          { id: 'symphony', displayValue: 'Symphony' },
+          { id: 'labyrinth', displayValue: 'Labyrinth' },
+        ]}
+      />
+    );
+  },
 };

--- a/src/BasicInputs/stories/ModelInput.stories.tsx
+++ b/src/BasicInputs/stories/ModelInput.stories.tsx
@@ -6,6 +6,7 @@ import { ModelInput } from '../ModelInput';
 
 const meta = {
   title: 'Commons/BasicInputs/ModelInput',
+  component: ModelInput,
   tags: ['autodocs'],
   args: {
     options: [
@@ -21,7 +22,6 @@ const meta = {
       { id: 'labyrinth', displayValue: 'Labyrinth' },
     ],
   },
-  component: ModelInput,
 } satisfies Meta<typeof ModelInput>;
 export default meta;
 

--- a/src/BasicInputs/stories/ModelInput.stories.tsx
+++ b/src/BasicInputs/stories/ModelInput.stories.tsx
@@ -19,22 +19,22 @@ const meta = {
       { id: 'labyrinth', displayValue: 'Labyrinth' },
     ],
   },
-  component: ModelInput
+  component: ModelInput,
 } satisfies Meta<typeof ModelInput>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Select : Story = {}
+export const Select: Story = {};
 
-export const Creatable : Story = {
+export const Creatable: Story = {
   args: {
     isCreatable: true,
-  }
-} 
+  },
+};
 
-export const Multi : Story = {
+export const Multi: Story = {
   args: {
-    isMulti: true
-  }
-}
+    isMulti: true,
+  },
+};

--- a/src/BasicInputs/stories/SelectInput.stories.tsx
+++ b/src/BasicInputs/stories/SelectInput.stories.tsx
@@ -35,6 +35,6 @@ export const CreatableSelect: Story = {
 
 export const MultiSelect: Story = {
   args: {
-    isMulti: true
-  }
-}
+    isMulti: true,
+  },
+};

--- a/src/BasicInputs/stories/SelectInput.stories.tsx
+++ b/src/BasicInputs/stories/SelectInput.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { SelectInput } from '../SelectInput';
+import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/SelectInput',
@@ -34,9 +35,26 @@ export const CreatableSelect: Story = {
 };
 
 export const MultiSelect: Story = {
-  args: {
-    isMulti: true,
-  },
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return <SelectInput
+      value={value}
+      onChange={setValue}
+      isCreatable
+      options={[
+        { value: 'apple', label: 'Apple' },
+        { value: 'mountain', label: 'Mountain' },
+        { value: 'ocean', label: 'Ocean' },
+        { value: 'whisper', label: 'Whisper' },
+        { value: 'butterfly', label: 'Butterfly' },
+        { value: 'galaxy', label: 'Galaxy' },
+        { value: 'harmony', label: 'Harmony' },
+        { value: 'puzzle', label: 'Puzzle' },
+        { value: 'symphony', label: 'Symphony' },
+        { value: 'labyrinth', label: 'Labyrinth' },
+      ]}
+    />
+  }
 };
 
 export const PortalTarget: Story = {

--- a/src/BasicInputs/stories/SelectInput.stories.tsx
+++ b/src/BasicInputs/stories/SelectInput.stories.tsx
@@ -22,6 +22,15 @@ const meta = {
       { value: 'labyrinth', label: 'Labyrinth' },
     ],
   },
+  render: (props) => {
+    const [values, setValues] = useState<any>(props.value);
+    return (
+      <div className="space-y-2">
+        <div>Value: {JSON.stringify(values)}</div>
+        <SelectInput {...props} value={values} onChange={setValues} />
+      </div>
+    );
+  },
 } satisfies Meta<typeof SelectInput>;
 export default meta;
 
@@ -36,47 +45,20 @@ export const CreatableSelect: Story = {
 };
 
 export const MultiSelect: Story = {
-  render: () => {
-    const [value, setValue] = useState<string[]>([]);
-    return (
-      <SelectInput
-        value={value}
-        onChange={setValue}
-        isCreatable
-        options={[
-          { value: 'apple', label: 'Apple' },
-          { value: 'mountain', label: 'Mountain' },
-          { value: 'ocean', label: 'Ocean' },
-          { value: 'whisper', label: 'Whisper' },
-          { value: 'butterfly', label: 'Butterfly' },
-          { value: 'galaxy', label: 'Galaxy' },
-          { value: 'harmony', label: 'Harmony' },
-          { value: 'puzzle', label: 'Puzzle' },
-          { value: 'symphony', label: 'Symphony' },
-          { value: 'labyrinth', label: 'Labyrinth' },
-        ]}
-      />
-    );
+  args: {
+    isMulti: true,
   },
 };
 
-export const PortalTarget: Story = {
-  render: (props) => {
-    return (
-      <div className="flex h-80 items-center justify-center bg-black">
-        <div
-          id="select-portal"
-          className="relative flex h-72 w-full items-end justify-center bg-blue-300"
-        >
-          <div className="absolute h-24 bg-green-300">
-            <SelectInput
-              {...props}
-              maxMenuHeight={100}
-              menuPortalTarget={document.getElementById('select-portal')}
-            />
-          </div>
-        </div>
-      </div>
-    );
+export const CreatableMultiSelect: Story = {
+  args: {
+    isMulti: true,
+    isCreatable: true,
+  },
+};
+
+export const MultiSelectWithValueInference: Story = {
+  args: {
+    value: [],
   },
 };

--- a/src/BasicInputs/stories/SelectInput.stories.tsx
+++ b/src/BasicInputs/stories/SelectInput.stories.tsx
@@ -32,3 +32,9 @@ export const CreatableSelect: Story = {
     isCreatable: true,
   },
 };
+
+export const MultiSelect: Story = {
+  args: {
+    isMulti: true
+  }
+}

--- a/src/BasicInputs/stories/SelectInput.stories.tsx
+++ b/src/BasicInputs/stories/SelectInput.stories.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { SelectInput } from '../SelectInput';
-import { useState } from 'react';
 
 const meta = {
   title: 'Commons/BasicInputs/SelectInput',
@@ -37,24 +38,26 @@ export const CreatableSelect: Story = {
 export const MultiSelect: Story = {
   render: () => {
     const [value, setValue] = useState<string[]>([]);
-    return <SelectInput
-      value={value}
-      onChange={setValue}
-      isCreatable
-      options={[
-        { value: 'apple', label: 'Apple' },
-        { value: 'mountain', label: 'Mountain' },
-        { value: 'ocean', label: 'Ocean' },
-        { value: 'whisper', label: 'Whisper' },
-        { value: 'butterfly', label: 'Butterfly' },
-        { value: 'galaxy', label: 'Galaxy' },
-        { value: 'harmony', label: 'Harmony' },
-        { value: 'puzzle', label: 'Puzzle' },
-        { value: 'symphony', label: 'Symphony' },
-        { value: 'labyrinth', label: 'Labyrinth' },
-      ]}
-    />
-  }
+    return (
+      <SelectInput
+        value={value}
+        onChange={setValue}
+        isCreatable
+        options={[
+          { value: 'apple', label: 'Apple' },
+          { value: 'mountain', label: 'Mountain' },
+          { value: 'ocean', label: 'Ocean' },
+          { value: 'whisper', label: 'Whisper' },
+          { value: 'butterfly', label: 'Butterfly' },
+          { value: 'galaxy', label: 'Galaxy' },
+          { value: 'harmony', label: 'Harmony' },
+          { value: 'puzzle', label: 'Puzzle' },
+          { value: 'symphony', label: 'Symphony' },
+          { value: 'labyrinth', label: 'Labyrinth' },
+        ]}
+      />
+    );
+  },
 };
 
 export const PortalTarget: Story = {

--- a/src/ModelTable/stories/ModelTable.stories.tsx
+++ b/src/ModelTable/stories/ModelTable.stories.tsx
@@ -180,7 +180,7 @@ export const NoData: Story = {
   },
 };
 
-export const ReadOnly = {
+export const ReadOnly: Story = {
   args: {
     tableOptions: {
       readOnly: true,


### PR DESCRIPTION
### Changes
* Added multi-select story for SelectInput and stories for ModelInput
* All Selectable components (Cretable, SelectInput, EnumInput) are clearable by default and do not close menu if isMulti (for consistency)
* Fixed EnumInput not being able to select or create options
* Changed EnumInput value prop type to `string | string[]` to support single or multiple selections
* Updated EnumInput stories to correctly showcase each selection type
* Removed redundant props in ModelInput and SelectInput