### PR TITLE
feat: change View button icon when columns are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.12.0
+`feature`: `FieldVisibility` icon changes to EyeOff when filtering columns.
+
 ## 1.11.3
 `bugfix`: Action props and actions now propagates properly.
 

--- a/src/ModelTable/FieldVisibility.tsx
+++ b/src/ModelTable/FieldVisibility.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { Eye } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 
 import { Button } from '@/lib/components/ui/button';
 import {
@@ -33,12 +33,18 @@ export const FieldVisibility = <F extends string, T extends F>({
   options,
   children,
 }: FieldVisibilityProps<F, T>) => {
+  const isFiltered = fields.length !== fieldOrder.length;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         {children ?? (
           <Button variant="outline" size="sm" className="h-8">
-            <Eye className="mr-2 h-4 w-4" />
+            {isFiltered ? (
+              <EyeOff className="mr-2 h-4 w-4" />
+            ) : (
+              <Eye className="mr-2 h-4 w-4" />
+            )}
             View
           </Button>
         )}


### PR DESCRIPTION
Adds signifier for the user when table columns are being hidden by the `FieldVisibility` by changing the icon to `EyeOff`.